### PR TITLE
fix bug: upnp can't compile on windows vs 2005

### DIFF
--- a/build/vc8/ixml.vcproj
+++ b/build/vc8/ixml.vcproj
@@ -103,8 +103,8 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalIncludeDirectories="..\..\ixml\inc;..\..\ixml\src\inc;..\inc"
-				PreprocessorDefinitions="WIN32;IXML_INLINE="
+				AdditionalIncludeDirectories="..\..\ixml\inc;..\..\ixml\src\inc;..\inc;..\..\upnp\inc"
+				PreprocessorDefinitions="WIN32;DEBUG;IXML_INLINE="
 				RuntimeLibrary="0"
 				WarningLevel="3"
 				Detect64BitPortabilityProblems="true"

--- a/build/vc8/libupnp.vcproj
+++ b/build/vc8/libupnp.vcproj
@@ -50,7 +50,7 @@
 				Optimization="2"
 				InlineFunctionExpansion="1"
 				AdditionalIncludeDirectories="..\..\pthreads\include;..\..\ixml\src\inc;..\..\ixml\inc;..\..\threadutil\inc;..\..\upnp\inc;..\..\upnp\src\inc;..\inc;..\msvc"
-				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBUPNP_EXPORTS;PTW32_STATIC_LIB;UPNP_STATIC_LIB;UPNP_USE_MSVCPP;_CRT_SECURE_NO_WARNINGS"
+				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBUPNP_EXPORTS;PTW32_STATIC_LIB;UPNP_USE_MSVCPP;_CRT_SECURE_NO_WARNINGS"
 				StringPooling="true"
 				RuntimeLibrary="0"
 				EnableFunctionLevelLinking="true"
@@ -80,8 +80,8 @@
 				OutputFile="$(OutDir)\libupnp.dll"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
-				ProgramDatabaseFile=".\Release/libupnp.pdb"
-				ImportLibrary=".\Release/libupnp.lib"
+				ProgramDatabaseFile="$(OutDir)\libupnp.pdb"
+				ImportLibrary="$(OutDir)\libupnp.lib"
 				TargetMachine="1"
 			/>
 			<Tool
@@ -96,7 +96,7 @@
 			<Tool
 				Name="VCBscMakeTool"
 				SuppressStartupBanner="true"
-				OutputFile=".\Release/libupnp.bsc"
+				OutputFile="$(OutDir)\libupnp.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"
@@ -232,6 +232,10 @@
 			</File>
 			<File
 				RelativePath="..\..\upnp\src\genlib\client_table\client_table.c"
+				>
+			</File>
+			<File
+				RelativePath="..\..\upnp\src\genlib\client_table\ClientSubscription.c"
 				>
 			</File>
 			<File

--- a/build/vc8/threadutil.vcproj
+++ b/build/vc8/threadutil.vcproj
@@ -40,7 +40,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="..\..\threadutil\inc;..\..\upnp\inc;..\..\ixml\inc;..\..\pthreads\include"
-				PreprocessorDefinitions="WIN32;DEBUG"
+				PreprocessorDefinitions="WIN32;DEBUG;UPNP_USE_MSVCPP"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -80,9 +80,9 @@
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
-			OutputDirectory="$(SolutionDir)$(ConfigurationName)"
-			IntermediateDirectory="$(ConfigurationName)"
-			ConfigurationType="1"
+			OutputDirectory=".\out.vc8.$(ConfigurationName)\$(ProjectName)"
+			IntermediateDirectory=".\out.vc8.$(ConfigurationName)\$(ProjectName)"
+			ConfigurationType="4"
 			CharacterSet="2"
 			WholeProgramOptimization="1"
 			>
@@ -103,6 +103,8 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
+				AdditionalIncludeDirectories="..\..\threadutil\inc;..\..\upnp\inc;..\..\ixml\inc;..\..\pthreads\include"
+				PreprocessorDefinitions="WIN32;UPNP_USE_MSVCPP"
 				RuntimeLibrary="2"
 				WarningLevel="3"
 				Detect64BitPortabilityProblems="true"
@@ -118,17 +120,10 @@
 				Name="VCPreLinkEventTool"
 			/>
 			<Tool
-				Name="VCLinkerTool"
-				GenerateDebugInformation="true"
-				OptimizeReferences="2"
-				EnableCOMDATFolding="2"
-				TargetMachine="1"
+				Name="VCLibrarianTool"
 			/>
 			<Tool
 				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
 			/>
 			<Tool
 				Name="VCXDCMakeTool"
@@ -138,12 +133,6 @@
 			/>
 			<Tool
 				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCWebDeploymentTool"
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"

--- a/build/vc8/tvcombo.vcproj
+++ b/build/vc8/tvcombo.vcproj
@@ -40,7 +40,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="..\..\upnp\inc;..\..\ixml\inc;..\..\upnp\sample\common;..\inc;..\..\threadutil\inc;..\..\pthreads\include;..\..\upnp\sample\tvcombo;..\..\upnp\sample\tvcombo\linux"
-				PreprocessorDefinitions="WIN32;DEBUG"
+				PreprocessorDefinitions="WIN32;DEBUG;UPNP_USE_MSVCPP"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -91,8 +91,8 @@
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
-			OutputDirectory="$(SolutionDir)$(ConfigurationName)"
-			IntermediateDirectory="$(ConfigurationName)"
+			OutputDirectory=".\out.vc8.$(ConfigurationName)\$(ProjectName)"
+			IntermediateDirectory=".\out.vc8.$(ConfigurationName)\$(ProjectName)"
 			ConfigurationType="1"
 			CharacterSet="2"
 			WholeProgramOptimization="1"
@@ -114,6 +114,8 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
+				AdditionalIncludeDirectories="..\..\upnp\inc;..\..\ixml\inc;..\..\upnp\sample\common;..\inc;..\..\threadutil\inc;..\..\pthreads\include;..\..\upnp\sample\tvcombo;..\..\upnp\sample\tvcombo\linux"
+				PreprocessorDefinitions="WIN32;UPNP_USE_MSVCPP"
 				RuntimeLibrary="2"
 				WarningLevel="3"
 				Detect64BitPortabilityProblems="true"
@@ -130,6 +132,8 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="..\..\pthreads\lib\pthreadVC2.lib ixml.lib threadutil.lib libupnp.lib"
+				AdditionalLibraryDirectories="&quot;$(OutDir)&quot;;&quot;out.vc8.$(ConfigurationName)\ixml&quot;;&quot;out.vc8.$(ConfigurationName)\threadutil&quot;;&quot;out.vc8.$(ConfigurationName)\libupnp&quot;"
 				GenerateDebugInformation="true"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
@@ -174,15 +178,15 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\upnp\sample\tvcombo\linux\upnp_tv_combo_main.c"
+				RelativePath="..\..\upnp\sample\linux\tv_combo_main.c"
 				>
 			</File>
 			<File
-				RelativePath="..\..\upnp\sample\tvcombo\upnp_tv_ctrlpt.c"
+				RelativePath="..\..\upnp\sample\common\tv_ctrlpt.c"
 				>
 			</File>
 			<File
-				RelativePath="..\..\upnp\sample\tvcombo\upnp_tv_device.c"
+				RelativePath="..\..\upnp\sample\common\tv_device.c"
 				>
 			</File>
 		</Filter>

--- a/build/vc8/tvctrlpt.vcproj
+++ b/build/vc8/tvctrlpt.vcproj
@@ -40,7 +40,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="..\..\upnp\inc;..\..\ixml\inc;..\..\upnp\sample\common;..\inc;..\..\threadutil\inc;..\..\pthreads\include;..\..\upnp\sample\tvctrlpt;..\..\upnp\sample\tvctrlpt\linux"
-				PreprocessorDefinitions="WIN32;DEBUG"
+				PreprocessorDefinitions="WIN32;DEBUG;UPNP_USE_MSVCPP"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -91,8 +91,8 @@
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
-			OutputDirectory="$(SolutionDir)$(ConfigurationName)"
-			IntermediateDirectory="$(ConfigurationName)"
+			OutputDirectory=".\out.vc8.$(ConfigurationName)\$(ProjectName)"
+			IntermediateDirectory=".\out.vc8.$(ConfigurationName)\$(ProjectName)"
 			ConfigurationType="1"
 			CharacterSet="2"
 			WholeProgramOptimization="1"
@@ -114,6 +114,8 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
+				AdditionalIncludeDirectories="..\..\upnp\inc;..\..\ixml\inc;..\..\upnp\sample\common;..\inc;..\..\threadutil\inc;..\..\pthreads\include;..\..\upnp\sample\tvctrlpt;..\..\upnp\sample\tvctrlpt\linux"
+				PreprocessorDefinitions="WIN32;UPNP_USE_MSVCPP"
 				RuntimeLibrary="2"
 				WarningLevel="3"
 				Detect64BitPortabilityProblems="true"
@@ -130,6 +132,8 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="..\..\pthreads\lib\pthreadVC2.lib ixml.lib threadutil.lib  libupnp.lib"
+				AdditionalLibraryDirectories="&quot;$(OutDir)&quot;;&quot;out.vc8.$(ConfigurationName)\ixml&quot;;&quot;out.vc8.$(ConfigurationName)\threadutil&quot;;&quot;out.vc8.$(ConfigurationName)\libupnp&quot;"
 				GenerateDebugInformation="true"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
@@ -174,11 +178,11 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\upnp\sample\tvctrlpt\upnp_tv_ctrlpt.c"
+				RelativePath="..\..\upnp\sample\common\tv_ctrlpt.c"
 				>
 			</File>
 			<File
-				RelativePath="..\..\upnp\sample\tvctrlpt\linux\upnp_tv_ctrlpt_main.c"
+				RelativePath="..\..\upnp\sample\linux\tv_ctrlpt_main.c"
 				>
 			</File>
 		</Filter>

--- a/build/vc8/tvdevice.vcproj
+++ b/build/vc8/tvdevice.vcproj
@@ -40,7 +40,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="..\..\upnp\inc;..\..\ixml\inc;..\..\upnp\sample\common;..\inc;..\..\threadutil\inc;..\..\pthreads\include;..\..\upnp\sample\tvdevice;..\..\upnp\sample\tvdevice\linux"
-				PreprocessorDefinitions="WIN32;DEBUG"
+				PreprocessorDefinitions="WIN32;DEBUG;UPNP_USE_MSVCPP"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -91,8 +91,8 @@
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
-			OutputDirectory="$(SolutionDir)$(ConfigurationName)"
-			IntermediateDirectory="$(ConfigurationName)"
+			OutputDirectory=".\out.vc8.$(ConfigurationName)\$(ProjectName)"
+			IntermediateDirectory=".\out.vc8.$(ConfigurationName)\$(ProjectName)"
 			ConfigurationType="1"
 			CharacterSet="2"
 			WholeProgramOptimization="1"
@@ -114,6 +114,8 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
+				AdditionalIncludeDirectories="..\..\upnp\inc;..\..\ixml\inc;..\..\upnp\sample\common;..\inc;..\..\threadutil\inc;..\..\pthreads\include;..\..\upnp\sample\tvdevice;..\..\upnp\sample\tvdevice\linux"
+				PreprocessorDefinitions="WIN32;UPNP_USE_MSVCPP"
 				RuntimeLibrary="2"
 				WarningLevel="3"
 				Detect64BitPortabilityProblems="true"
@@ -130,6 +132,8 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
+				AdditionalDependencies="..\..\pthreads\lib\pthreadVC2.lib ixml.lib threadutil.lib libupnp.lib"
+				AdditionalLibraryDirectories="&quot;$(OutDir)&quot;;&quot;out.vc8.$(ConfigurationName)\ixml&quot;;&quot;out.vc8.$(ConfigurationName)\threadutil&quot;;&quot;out.vc8.$(ConfigurationName)\libupnp&quot;"
 				GenerateDebugInformation="true"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
@@ -174,11 +178,11 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\upnp\sample\tvdevice\upnp_tv_device.c"
+				RelativePath="..\..\upnp\sample\common\tv_device.c"
 				>
 			</File>
 			<File
-				RelativePath="..\..\upnp\sample\tvdevice\linux\upnp_tv_device_main.c"
+				RelativePath="..\..\upnp\sample\linux\tv_device_main.c"
 				>
 			</File>
 		</Filter>


### PR DESCRIPTION
- define UPNP_USE_MSVCPP when necessary
- set release build's output directory to be consistent with debug build
- add missing ClientSubscription.c to libupnp project
- reference correct source files in sample project
