### PR TITLE
add CtrlPtIPAddr to UpnpFileInfo class

### DIFF
--- a/upnp/inc/FileInfo.h
+++ b/upnp/inc/FileInfo.h
@@ -12,6 +12,7 @@
  */
 
 #include "upnpconfig.h"
+#include "UpnpInet.h" /* for struct sockaddr_storage */
 
 #include <sys/types.h>  /* for off_t */
 #include <time.h>       /* for time_t */
@@ -29,6 +30,7 @@
 	EXPAND_CLASS_MEMBER_INT(CLASS, IsReadable, int) \
 	EXPAND_CLASS_MEMBER_DOMSTRING(CLASS, ContentType) \
 	EXPAND_CLASS_MEMBER_LIST(CLASS, ExtraHeadersList) \
+	EXPAND_CLASS_MEMBER_BUFFER(CLASS, CtrlPtIPAddr, struct sockaddr_storage) \
 
 #include "TemplateInclude.h"
 

--- a/upnp/src/genlib/net/http/webserver.c
+++ b/upnp/src/genlib/net/http/webserver.c
@@ -1132,6 +1132,8 @@ static int ExtraHTTPHeaders(
  * \li \c HTTP_OK
  */
 static int process_request(
+	/*! [in] Socket info. */
+	SOCKINFO *info,
 	/*! [in] HTTP Request message. */
 	http_message_t *req,
 	/*! [out] Tpye of response. */
@@ -1231,6 +1233,8 @@ static int process_request(
 				err_code = code;
 				goto error_handler;
 			}
+
+			UpnpFileInfo_set_CtrlPtIPAddr(finfo, &info->foreign_sockaddr);
 
 			/* get file info */
 			if (virtualDirCallback.get_info(filename->buf,
@@ -1681,7 +1685,7 @@ void web_server_callback(
 	 * on the */
 	/*the type of request. */
 	ret = process_request(
-		req, &rtype, &headers, &filename, &xmldoc, &RespInstr);
+		info, req, &rtype, &headers, &filename, &xmldoc, &RespInstr);
 	if (ret != HTTP_OK) {
 		/* send error code */
 		http_SendStatusResponse(


### PR DESCRIPTION
Similar to UpnpActionRequest class add  CtrlPtIPAddr member. This implementation is mostly a copy/paste from UpnpActionRequest path.

This information can later be used by devices (Gerbera https://github.com/gerbera/gerbera) to inject client (e.g. SamsungTV) specific quirks. Like extra headers, special mime types, etc...
