### PR TITLE
add Os/UserAgent information to UpnpActionRequest and UpnpFileInfo

### DIFF
--- a/upnp/inc/ActionRequest.h
+++ b/upnp/inc/ActionRequest.h
@@ -28,6 +28,7 @@
 	EXPAND_CLASS_MEMBER_INT(CLASS, ActionResult, IXML_Document *) \
 	EXPAND_CLASS_MEMBER_INT(CLASS, SoapHeader, IXML_Document *) \
 	EXPAND_CLASS_MEMBER_BUFFER(CLASS, CtrlPtIPAddr, struct sockaddr_storage) \
+	EXPAND_CLASS_MEMBER_STRING(CLASS, Os) \
 
 #include "TemplateInclude.h"
 

--- a/upnp/inc/FileInfo.h
+++ b/upnp/inc/FileInfo.h
@@ -31,6 +31,7 @@
 	EXPAND_CLASS_MEMBER_DOMSTRING(CLASS, ContentType) \
 	EXPAND_CLASS_MEMBER_LIST(CLASS, ExtraHeadersList) \
 	EXPAND_CLASS_MEMBER_BUFFER(CLASS, CtrlPtIPAddr, struct sockaddr_storage) \
+	EXPAND_CLASS_MEMBER_STRING(CLASS, Os) \
 
 #include "TemplateInclude.h"
 

--- a/upnp/src/genlib/net/http/webserver.c
+++ b/upnp/src/genlib/net/http/webserver.c
@@ -1161,6 +1161,7 @@ static int process_request(
 	int resp_minor;
 	int alias_grabbed;
 	size_t dummy;
+	memptr hdr_value;
 
 	print_http_headers(req);
 	url = &req->uri;
@@ -1235,6 +1236,10 @@ static int process_request(
 			}
 
 			UpnpFileInfo_set_CtrlPtIPAddr(finfo, &info->foreign_sockaddr);
+
+			if (httpmsg_find_hdr(req, HDR_USER_AGENT, &hdr_value) != NULL) {
+				UpnpFileInfo_strncpy_Os(finfo, hdr_value.buf, hdr_value.length);
+			}
 
 			/* get file info */
 			if (virtualDirCallback.get_info(filename->buf,

--- a/upnp/src/soap/soap_device.c
+++ b/upnp/src/soap/soap_device.c
@@ -393,6 +393,7 @@ static void handle_invoke_action(
 	const char *err_str;
 	memptr action_name;
 	DOMString act_node = NULL;
+	memptr hdr_value;
 
 	/* null-terminate */
 	action_name = soap_info->action_name;
@@ -423,6 +424,10 @@ static void handle_invoke_action(
 	UpnpActionRequest_set_ActionRequest(action, actionRequestDoc);
 	UpnpActionRequest_set_ActionResult(action, NULL);
 	UpnpActionRequest_set_CtrlPtIPAddr(action, &info->foreign_sockaddr);
+
+	if (httpmsg_find_hdr(request, HDR_USER_AGENT, &hdr_value) != NULL) {
+		UpnpActionRequest_strncpy_Os(action, hdr_value.buf, hdr_value.length);
+	}
 
 	UpnpPrintf(UPNP_INFO, SOAP, __FILE__, __LINE__, "Calling Callback\n");
 	soap_info->callback(


### PR DESCRIPTION
Similar to UpnpDiscovery class add Os member. This implementation is mostly a copy/paste from UpnpDiscovery path, except that i do only look for "USER-AGENT" and not the "SERVER" header entry, as i think the "SERVER" part makes no sense for those "client to server" requests. 

This will give us more flexibility in Gerbera (https://github.com/gerbera/gerbera) when applying quirks.
With this information we can directly use the "USER-AGENT" implementation. For devices where "USER-AGENT" is not good enough, we can use the discovery/CtrlPtIPAddr path.

Works like a charm for VLC + BubbleUPnP