### PR TITLE
[1.8.x]Do not use usleep when using newer POSIX C source.

### DIFF
--- a/upnp/inc/ithread.h
+++ b/upnp/inc/ithread.h
@@ -928,7 +928,15 @@ static UPNP_INLINE int ithread_cleanup_thread(void) {
 #ifdef _WIN32
 	#define imillisleep Sleep
 #else
-	#define imillisleep(x) usleep(1000*x)
+#if _POSIX_C_SOURCE < 200809L
+	#define imillisleep(x) usleep(1000 * x)
+#else
+	#define imillisleep(x) \
+		do { \
+			const struct timespec req = {0, x * 1000 * 1000}; \
+			nanosleep(&req, NULL); \
+		} while(0)
+#endif
 #endif
 
 

--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -905,7 +905,7 @@ int StartMiniServer(
 	count = 0;
 	while (gMServState != (MiniServerState)MSERV_RUNNING && count < max_count) {
 		/* 0.05s */
-		usleep(50u * 1000u);
+		imillisleep(50);
 		count++;
 	}
 	if (count >= max_count) {
@@ -960,7 +960,7 @@ int StopMiniServer()
 		ssdpAddr.sin_port = htons(miniStopSockPort);
 		sendto(sock, buf, bufLen, 0,
 			(struct sockaddr *)&ssdpAddr, socklen);
-		usleep(1000u);
+		imillisleep(1);
 		if (gMServState == (MiniServerState)MSERV_IDLE) {
 			break;
 		}


### PR DESCRIPTION
usleep is deprecated and is optionally unavailable with uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>
(cherry picked from commit c91d82a7b74df3a08de2f94a1ec2a75a7803b6bd)

Version 1.8 is used in OpenWrt as later versions cause some incompatibility problems.