### PR TITLE
backport mediatomb fix, but place it in httpparser

### DIFF
--- a/upnp/src/genlib/net/http/httpparser.c
+++ b/upnp/src/genlib/net/http/httpparser.c
@@ -1285,6 +1285,11 @@ parser_parse_requestline( http_parser_t * parser )
 
 	hmsg->method = HTTPMETHOD_SIMPLEGET;
 
+	/* remove excessive leading slashes, keep one slash */
+	while ( url_str.length >= 2 && url_str.buf[0] == '/' && url_str.buf[1] == '/' ) {
+		url_str.buf++;
+		url_str.length--;
+	}
 	/* store url */
 	hmsg->urlbuf = str_alloc( url_str.buf, url_str.length );
 	if( hmsg->urlbuf == NULL ) {
@@ -1307,6 +1312,11 @@ parser_parse_requestline( http_parser_t * parser )
 		    &version_str );
     if( status != ( parse_status_t ) PARSE_OK ) {
 	return status;
+    }
+    /* remove excessive leading slashes, keep one slash */
+    while ( url_str.length >= 2 && url_str.buf[0] == '/' && url_str.buf[1] == '/' ) {
+		url_str.buf++;
+		url_str.length--;
     }
     /* store url */
     hmsg->urlbuf = str_alloc( url_str.buf, url_str.length );


### PR DESCRIPTION
Original patch:
https://sourceforge.net/p/mediatomb/code/ci/2753e70013636bb5dd4cfc595f9776d368709f04/tree/tombupnp/upnp/src/genlib/net/uri/uri.c?diff=6be2b0d6e512fd60f155acf78b1f7c1725f58571

This patch is needed for "Samsung Smart TV 2012" and older. ~~But it also makes `parse_uri` more robust for everybody:~~
- ~~the schema should only be looked at when we found a schema at all~~
- ~~multiple slashes in URLs are actually allowed and can happen~~

Parse `GET \\cm.xml` to:
- Method = GET
- URL = `\cm.xml` instead of `\\cm.xml`