### PR TITLE
Improve traceability of debug message in ThreadPool

### DIFF
--- a/upnp/src/threadutil/ThreadPool.c
+++ b/upnp/src/threadutil/ThreadPool.c
@@ -822,7 +822,7 @@ int ThreadPoolAdd(ThreadPool *tp, ThreadPoolJob *job, int *jobId)
 
 	totalJobs = tp->highJobQ.size + tp->lowJobQ.size + tp->medJobQ.size;
 	if (totalJobs >= tp->attr.maxJobsTotal) {
-		fprintf(stderr, "total jobs = %ld, too many jobs", totalJobs);
+		fprintf(stderr, "libupnp ThreadPoolAdd too many jobs: %ld\n", totalJobs);
 		goto exit_function;
 	}
 	if (!jobId)


### PR DESCRIPTION
Add libupnp prefix and function name for easier recognizability, this message
  usually end up mixed in logs of other applications using libupnp.
Add missing new line to avoid mangling other log messages.