### PR TITLE
Partial fix for CallStranger on IPv4

### DIFF
--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -137,6 +137,9 @@ char gIF_NAME[LINE_SIZE] = {'\0'};
 /*! Static buffer to contain interface IPv4 address. (extern'ed in upnp.h) */
 char gIF_IPV4[INET_ADDRSTRLEN] = {'\0'};
 
+/*! Static buffer to contain interface IPv4 netmask. (extern'ed in upnp.h) */
+char gIF_IPV4_NETMASK[INET_ADDRSTRLEN] = {'\0'};
+
 /*! Static buffer to contain interface IPv6 address. (extern'ed in upnp.h) */
 char gIF_IPV6[INET6_ADDRSTRLEN] = {'\0'};
 
@@ -3932,8 +3935,8 @@ int UpnpGetIfInfo(const char *IfName)
 		}
 		/* Check address family. */
 		if (pifReq->ifr_addr.sa_family == AF_INET) {
-			/* Copy interface name, IPv4 address and interface
-			 * index. */
+			/* Copy interface name, IPv4 address, IPv4 netmask and
+			 * interface index. */
 			memset(gIF_NAME, 0, sizeof(gIF_NAME));
 			strncpy(gIF_NAME,
 				pifReq->ifr_name,
@@ -3943,6 +3946,19 @@ int UpnpGetIfInfo(const char *IfName)
 					 ->sin_addr,
 				gIF_IPV4,
 				sizeof(gIF_IPV4));
+			if (ioctl(LocalSock, SIOCGIFNETMASK, &ifReq) < 0) {
+				UpnpPrintf(UPNP_ALL,
+					API,
+					__FILE__,
+					__LINE__,
+					"Can't get interface netmask for %s:\n",
+					ifReq.ifr_name);
+			}
+			inet_ntop(AF_INET,
+				&((struct sockaddr_in *)&ifReq.ifr_netmask)
+					 ->sin_addr,
+				gIF_IPV4_NETMASK,
+				sizeof(gIF_IPV4_NETMASK));
 			gIF_INDEX = if_nametoindex(gIF_NAME);
 			valid_addr_found = 1;
 			break;

--- a/upnp/src/inc/upnpapi.h
+++ b/upnp/src/inc/upnpapi.h
@@ -211,6 +211,7 @@ Upnp_Handle_Type GetDeviceHandleInfoForPath(
 
 extern char gIF_NAME[LINE_SIZE];
 extern char gIF_IPV4[INET_ADDRSTRLEN];
+extern char gIF_IPV4_NETMASK[INET_ADDRSTRLEN];
 extern char gIF_IPV6[INET6_ADDRSTRLEN];
 
 extern char gIF_IPV6_ULA_GUA[INET6_ADDRSTRLEN];


### PR DESCRIPTION
This is a partial fix for CallStranger a.k.a. CVE-2020-12695

Check that DeliveryURLs are in the expected network segment as requested
by the new UPnP UDA:
https://openconnectivity.org/upnp-specs/UPnP-arch-DeviceArchitecture-v2.0-20200417.pdf.

Here is an extract of the new requirement:

The subscription request containing a delivery URL not on the same
network segment as the fully qualified event subscription URL shall not
be accepted. For private networks this means that the delivery URL
provided will adhere to the following IP ranges:

 - 10.0.0.0 - 10.255.255.255 (10/8 prefix)
 - 172.16.0.0 - 172.31.255.255 (172.16/12 prefix)
 - 192.168.0.0 - 192.168.255.255 (192.168/16 prefix)

In the context of pupnp, this means that the IPv4 netmask is now
retrieved when using UPnPInit2. Then, each DeliveryURL is checked
against the device's IPv4 address and netmask. If one of them are not
compliant, the whole subscription is rejected.

This first commit should be enhanced / updated to:
 - remove UPnPInit (it is deprecated for a long time) or update it so
   the user can also pass the netmask
 - fix IPv6
 - fix Windows code
 - retrieve the netmask in the BSD code of UPnPInit2

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>