### PR TITLE
Allow the miniserver to listen on ULA or GUA IPv6 address

### DIFF
--- a/upnp/inc/upnp.h
+++ b/upnp/inc/upnp.h
@@ -610,22 +610,35 @@ EXPORT_SPEC int UpnpFinish(void);
 EXPORT_SPEC unsigned short UpnpGetServerPort(void);
 
 /*!
- * \brief Returns the internal server IPv6 UPnP listening port.
+ * \brief Returns the internal server IPv6 link-local (LLA) UPnP listening port.
  *
  * If '0' is used as the port number in \b UpnpInit2, then this function can be
  * used to retrieve the actual port allocated to the SDK.
  *
  * \return
  * 	\li On success: The port on which an internal server is listening for
- *		IPv6 UPnP related requests.
+ *		IPv6 link-local (LLA) UPnP related requests.
  * 	\li On error: 0 is returned if \b UpnpInit2 has not succeeded.
  */
 EXPORT_SPEC unsigned short UpnpGetServerPort6(void);
 
 /*!
+ * \brief Returns the internal server IPv6 ULA or GUA UPnP listening port.
+ *
+ * If '0' is used as the port number in \b UpnpInit2, then this function can be
+ * used to retrieve the actual port allocated to the SDK.
+ *
+ * \return
+ * 	\li On success: The port on which an internal server is listening for
+ *		IPv6 ULA or GUA UPnP related requests.
+ * 	\li On error: 0 is returned if \b UpnpInit2 has not succeeded.
+ */
+EXPORT_SPEC unsigned short UpnpGetServerUlaGuaPort6(void);
+
+/*!
  * \brief Returns the local IPv4 listening ip address.
  *
- * If \c NULL is used as the IPv4 address in \b UpnpInit2, then this function can
+ * If \c NULL is used as the interface in \b UpnpInit2, then this function can
  * be used to retrieve the actual interface address on which device is running.
  *
  * \return
@@ -636,18 +649,30 @@ EXPORT_SPEC unsigned short UpnpGetServerPort6(void);
 EXPORT_SPEC char *UpnpGetServerIpAddress(void);
 
 /*!
- * \brief Returns the local IPv6 listening ip address.
+ * \brief Returns the IPv6 link-local listening ip address.
  *
- * If \c NULL is used as the IPv6 address in \b UpnpInit2, then this function can
+ * If \c NULL is used as the interface in \b UpnpInit2, then this function can
  * be used to retrieve the actual interface address on which device is running.
  *
  * \return
- * 	\li On success: The IPv6 address on which an internal server is
- * 		listening for UPnP related requests.
+ * 	\li On success: The IPv6 link-local address (LLA) on which an internal
+ * 		server is listening for UPnP related requests.
  * 	\li On error: \c NULL is returned if \b UpnpInit2 has not succeeded.
  */
 EXPORT_SPEC char *UpnpGetServerIp6Address(void);
 
+/*!
+ * \brief Returns the IPv6 unique-local or globally-unique listening ip address.
+ *
+ * If \c NULL is used as the interface in \b UpnpInit2, then this function can
+ * be used to retrieve the actual interface address on which device is running.
+ *
+ * \return
+ * 	\li On success: The IPv6 unique-local or globally-unique address
+ * 		(ULA or GUA) on which an internal server is listening for UPnP
+ *		related requests.
+ * 	\li On error: \c NULL is returned if \b UpnpInit2 has not succeeded.
+ */
 EXPORT_SPEC char *UpnpGetServerUlaGuaIp6Address(void);
 /*!
  * \brief Registers a device application with the UPnP Library.

--- a/upnp/sample/common/tv_device.h
+++ b/upnp/sample/common/tv_device.h
@@ -132,6 +132,10 @@ extern "C" {
 /*! This should be the maximum VARCOUNT from above */
 #define TV_MAXVARS TV_PICTURE_VARCOUNT
 
+#define IP_MODE_IPV4 1
+#define IP_MODE_IPV6_LLA 2
+#define IP_MODE_IPV6_ULA_GUA 3
+
 /*!
  * \brief Prototype for all actions. For each action that a service 
  * implements, there is a corresponding function with this prototype.
@@ -514,9 +518,9 @@ int TvDeviceDecreaseBrightness(
  * advertisements.
  */
 int TvDeviceStart(
-	/*! [in] ip address to initialize the sdk (may be NULL)
-	 * if null, then the first non null loopback address is used. */
-	char *ip_address,
+	/*! [in] interface to initialize the sdk (may be NULL)
+	 * if null, then the first non null interface is used. */
+	char *interface,
 	/*! [in] port number to initialize the sdk (may be 0)
 	 * if zero, then a random number is used. */
 	unsigned short port,
@@ -526,6 +530,9 @@ int TvDeviceStart(
 	/*! [in] path of web directory.
 	 * may be NULL. Default is ./web (for Linux) or ../tvdevice/web. */
 	const char *web_dir_path,
+	/*! [in] IP mode: IP_MODE_IPV4, IP_MODE_IPV6_LLA or
+	 * IP_MODE_IPV6_ULA_GUA. Default is IP_MODE_IPV4. */
+	int ip_mode,
 	/*! [in] print function to use. */
 	print_string pfun,
 	/*! [in] Non-zero if called from the combo application. */

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -140,11 +140,12 @@ char gIF_IPV4[INET_ADDRSTRLEN] = {'\0'};
 /*! Static buffer to contain interface IPv4 netmask. (extern'ed in upnp.h) */
 char gIF_IPV4_NETMASK[INET_ADDRSTRLEN] = {'\0'};
 
-/*! Static buffer to contain interface IPv6 address. (extern'ed in upnp.h) */
+/*! Static buffer to contain interface IPv6 link-local address (LLA).
+ * (extern'ed in upnp.h) */
 char gIF_IPV6[INET6_ADDRSTRLEN] = {'\0'};
 
-/*! Static buffer to contain interface ULA or GUA IPv6 address. (extern'ed in
- * upnp.h) */
+/*! Static buffer to contain interface IPv6 unique-local or globally-unique
+ * address (ULA or GUA). (extern'ed in upnp.h) */
 char gIF_IPV6_ULA_GUA[INET6_ADDRSTRLEN] = {'\0'};
 
 /*! Contains interface index. (extern'ed in upnp.h) */
@@ -153,8 +154,11 @@ unsigned gIF_INDEX = (unsigned)-1;
 /*! local IPv4 port for the mini-server */
 unsigned short LOCAL_PORT_V4;
 
-/*! local IPv6 port for the mini-server */
+/*! IPv6 LLA port for the mini-server */
 unsigned short LOCAL_PORT_V6;
+
+/*! IPv6 ULA or GUA port for the mini-server */
+unsigned short LOCAL_PORT_V6_ULA_GUA;
 
 /*! UPnP device and control point handle table  */
 static void *HandleTable[NUM_HANDLE];
@@ -438,7 +442,8 @@ static int UpnpInitStartServers(
 #if EXCLUDE_MINISERVER == 0
 	LOCAL_PORT_V4 = DestPort;
 	LOCAL_PORT_V6 = DestPort;
-	retVal = StartMiniServer(&LOCAL_PORT_V4, &LOCAL_PORT_V6);
+	LOCAL_PORT_V6_ULA_GUA = DestPort;
+	retVal = StartMiniServer(&LOCAL_PORT_V4, &LOCAL_PORT_V6, &LOCAL_PORT_V6_ULA_GUA);
 	if (retVal != UPNP_E_SUCCESS) {
 		UpnpPrintf(UPNP_CRITICAL,
 			API,
@@ -701,6 +706,18 @@ unsigned short UpnpGetServerPort6(void)
 		return 0u;
 
 	return LOCAL_PORT_V6;
+#else
+	return 0u;
+#endif
+}
+
+unsigned short UpnpGetServerUlaGuaPort6(void)
+{
+#ifdef UPNP_ENABLE_IPV6
+	if (UpnpSdkInit != 1)
+		return 0u;
+
+	return LOCAL_PORT_V6_ULA_GUA;
 #else
 	return 0u;
 #endif

--- a/upnp/src/inc/miniserver.h
+++ b/upnp/src/inc/miniserver.h
@@ -45,15 +45,17 @@ extern SOCKET gMiniServerStopSock;
 typedef struct MServerSockArray {
 	/*! IPv4 socket for listening for miniserver requests. */
 	SOCKET miniServerSock4;
-	/*! IPv6 Socket for listening for miniserver requests. */
+	/*! IPv6 LLA Socket for listening for miniserver requests. */
 	SOCKET miniServerSock6;
+	/*! IPv6 ULA or GUA Socket for listening for miniserver requests. */
+	SOCKET miniServerSock6UlaGua;
 	/*! Socket for stopping miniserver */
 	SOCKET miniServerStopSock;
 	/*! IPv4 SSDP Socket for incoming advertisments and search requests. */
 	SOCKET ssdpSock4;
-	/*! IPv6 SSDP Socket for incoming advertisments and search requests. */
+	/*! IPv6 LLA SSDP Socket for incoming advertisments and search requests. */
 	SOCKET ssdpSock6;
-	/*! IPv6 SSDP Socket for incoming advertisments and search requests. */
+	/*! IPv6 ULA or GUA SSDP Socket for incoming advertisments and search requests. */
 	SOCKET ssdpSock6UlaGua;
 	/* ! . */
 	uint16_t stopPort;
@@ -61,6 +63,8 @@ typedef struct MServerSockArray {
 	uint16_t miniServerPort4;
 	/* ! . */
 	uint16_t miniServerPort6;
+	/* ! . */
+	uint16_t miniServerPort6UlaGua;
 #ifdef INCLUDE_CLIENT_APIS
 	/*! IPv4 SSDP socket for sending search requests and receiving search
 	 * replies */
@@ -128,8 +132,11 @@ int StartMiniServer(
 	 * connections. */
 	uint16_t *listen_port4,
 	/*! [in,out] Port on which the server listens for incoming IPv6
-	 * connections. */
-	uint16_t *listen_port6);
+	 * LLA connections. */
+	uint16_t *listen_port6,
+	/*! [in,out] Port on which the server listens for incoming
+	 * IPv6 ULA or GUA connections. */
+	uint16_t *listen_port6UlaGua);
 
 /*!
  * \brief Stop and Shutdown the MiniServer and free socket resources.


### PR DESCRIPTION
Currently, the miniserver only listens on the link local `gIF_IPV6`
address, this is an issue as the link local address is only available on
the current link (e.g. Ethernet) and not on the IPv6 "LAN". In other
words, this IPv6 address is not reachable if there is a router between
the UPnP device and the UPnP Control Point (which is the case for most
of our users).

So open a socket for `gIF_IPV6_ULA_GUA` to allow a device to call
`UpnpRegisterRootDevice3` or `UpnpRegisterRootDevice4` with the following
DescUrl:

```
sprintf(descDocUrlUlaGua, "http://[%s]:%d/%s", UpnpGetServerUlaGuaIp6Address(),
    UpnpGetServerUlaGuaPort6(), g_vars.descDocName);
```

Also add a new `UpnpGetServerUlaGuaPort6` function to retrieve the port
for this ULA or GUA address (as it can be different from
`UpnpGetServerPort6()`).

Finally improve comments on those IPv6 functions in upnp.h and update
tv_device.c to make it IPv6 LLA or IPv6 LLA or GUA "aware".

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>