### PR TITLE
Remove port >= 49152 restriction

### DIFF
--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -854,10 +854,10 @@ static int get_miniserver_sockets(
 	}
 	/* As per the IANA specifications for the use of ports by applications
 	 * override the listen port passed in with the first available. */
-	if (listen_port4 < APPLICATION_LISTENING_PORT) {
+	if (listen_port4 == 0) {
 		listen_port4 = (uint16_t)APPLICATION_LISTENING_PORT;
 	}
-	if (listen_port6 < APPLICATION_LISTENING_PORT) {
+	if (listen_port6 == 0) {
 		listen_port6 = (uint16_t)APPLICATION_LISTENING_PORT;
 	}
 	if (listen_port6UlaGua < APPLICATION_LISTENING_PORT) {


### PR DESCRIPTION
The media server gerbera is using libupnp. I'm using it with a Yamaha Network Player NP S303 which expects the server port to be 8200. Configuring gerbera using this port is only possible when I remove the requirement that the port be >= 49152.

 This change removes that restriction. I think it is reasonable to assume that if a client requests a certain port number they know what they're doing. If they request port number 0, they get the default minimum port of 49152.

I have an alternative pull request which makes the change configurable.