### PR TITLE
Add config option to remove the port restriction >= 49152

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,11 @@ if test "x$enable_optssdp" = xyes ; then
 	enable_uuid=yes
 fi
 
+RT_BOOL_ARG_ENABLE([portrestriction], [yes], [minimum port number of 49152])
+if test "x$enable_portrestriction" = xno ; then
+        AC_DEFINE(UPNP_NO_PORT_RESTRICTION, 1, [see upnpconfig.h])
+fi
+
 RT_BOOL_ARG_ENABLE([soap], [yes], [SOAP part])
 if test "x$enable_soap" = xyes ; then
         AC_DEFINE(UPNP_HAVE_SOAP, 1, [see upnpconfig.h])

--- a/upnp/inc/upnpconfig.h.in
+++ b/upnp/inc/upnpconfig.h.in
@@ -97,6 +97,10 @@
  *  (i.e. configure --enable-soap) */
 #undef UPNP_HAVE_SOAP
 
+/** Defined to 1 if the library has been compiled without the restriction port >= 49152
+ *  (i.e. configure --disable-port-restriction) */
+#undef UPNP_NO_PORT_RESTRICTION
+
 /** Defined to 1 if the library has been compiled with the GENA part enabled
  *  (i.e. configure --enable-gena) */
 #undef UPNP_HAVE_GENA

--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -854,10 +854,18 @@ static int get_miniserver_sockets(
 	}
 	/* As per the IANA specifications for the use of ports by applications
 	 * override the listen port passed in with the first available. */
+#ifdef UPNP_NO_PORT_RESTRICTION
+	if (listen_port4 == 0) {
+#else
 	if (listen_port4 < APPLICATION_LISTENING_PORT) {
+#endif
 		listen_port4 = (uint16_t)APPLICATION_LISTENING_PORT;
 	}
+#ifdef UPNP_NO_PORT_RESTRICTION
+	if (listen_port6 == 0) {
+#else
 	if (listen_port6 < APPLICATION_LISTENING_PORT) {
+#endif
 		listen_port6 = (uint16_t)APPLICATION_LISTENING_PORT;
 	}
 	if (listen_port6UlaGua < APPLICATION_LISTENING_PORT) {


### PR DESCRIPTION
The media server gerbera is using libupnp. I'm using it with a Yamaha Network Player NP S303 which expects the server port to be 8200. Configuring gerbera using this port is only possible when I remove the requirement that the port be >= 49152.

This change introduces a configure option to remove that restriction. I think it is reasonable to assume that if a client requests a certain port number they know what they're doing. If they request port number 0, they get the default minimum port of 49152.

I have an alternative pull request which makes that change default. They are mutually exclusive.