### PR TITLE
upnpapi.c: fix windows build

### DIFF
--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -66,7 +66,6 @@
 #include <sys/stat.h>
 
 #include <assert.h>
-#include <ifaddrs.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
@@ -74,6 +73,7 @@
 #ifdef _WIN32
 /* Do not include these files */
 #else
+#include <ifaddrs.h>
 #include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/types.h>


### PR DESCRIPTION
Fix build failure on windows added by commit aa0166c9a87a6f02632a0c55fb6174b6a1bf8289

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>