### PR TITLE
upnp/src/api/upnpapi.c: don't set gIF_IPV4 if there is no IPv4

### DIFF
--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -889,6 +889,8 @@ static int get_miniserver_sockets(
 		if (ret_val) {
 			goto error;
 		}
+	}
+	if (ss6UlaGua.fd != INVALID_SOCKET) {
 		ret_val = do_bind_listen(&ss6UlaGua);
 		if (ret_val) {
 			goto error;

--- a/upnp/src/ssdp/ssdp_ctrlpt.c
+++ b/upnp/src/ssdp/ssdp_ctrlpt.c
@@ -606,7 +606,8 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 	/*ThreadData *ThData; */
 	ThreadPoolJob job;
 
-	if (!inet_pton(AF_INET, gIF_IPV4, &addrv4)) {
+	if (strlen(gIF_IPV4) > (size_t)0 &&
+		!inet_pton(AF_INET, gIF_IPV4, &addrv4)) {
 		return UPNP_E_INVALID_PARAM;
 	}
 

--- a/upnp/src/ssdp/ssdp_device.c
+++ b/upnp/src/ssdp/ssdp_device.c
@@ -196,7 +196,8 @@ static int NewRequestHandler(
 	char buf_ntop[INET6_ADDRSTRLEN];
 	int ret = UPNP_E_SUCCESS;
 
-	if (!inet_pton(AF_INET, gIF_IPV4, &replyAddr)) {
+	if (strlen(gIF_IPV4) > (size_t)0 &&
+		!inet_pton(AF_INET, gIF_IPV4, &replyAddr)) {
 		return UPNP_E_INVALID_PARAM;
 	}
 


### PR DESCRIPTION
Don't set gIF_IPV4 if no IPv4 is found to keep the default value of '\0' otherwise SSDP will try to register IPv4 multicast with address 0.0.0.0 which will result in a runtime failure

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>