### PR TITLE
samples: allow the user to specify the control point interface

### DIFF
--- a/upnp/sample/common/tv_ctrlpt.c
+++ b/upnp/sample/common/tv_ctrlpt.c
@@ -1265,26 +1265,24 @@ void *TvCtrlPointTimerLoop(void *args)
  *
  * \return TV_SUCCESS if everything went well, else TV_ERROR.
  */
-int TvCtrlPointStart(print_string printFunctionPtr,
+int TvCtrlPointStart(char *iface,
 	state_update updateFunctionPtr,
 	int combo)
 {
 	ithread_t timer_thread;
 	int rc;
 	unsigned short port = 0;
-	char *ip_address = NULL;
 
-	SampleUtil_Initialize(printFunctionPtr);
 	SampleUtil_RegisterUpdateFunction(updateFunctionPtr);
 
 	ithread_mutex_init(&DeviceListMutex, 0);
 
 	SampleUtil_Print("Initializing UPnP Sdk with\n"
-			 "\tipaddress = %s port = %u\n",
-		ip_address ? ip_address : "{NULL}",
+			 "\tinterface = %s port = %u\n",
+		iface ? iface : "{NULL}",
 		port);
 
-	rc = UpnpInit2(ip_address, port);
+	rc = UpnpInit2(iface, port);
 	if (rc != UPNP_E_SUCCESS) {
 		SampleUtil_Print("WinCEStart: UpnpInit2() Error: %d\n", rc);
 		if (!combo) {
@@ -1293,17 +1291,14 @@ int TvCtrlPointStart(print_string printFunctionPtr,
 			return TV_ERROR;
 		}
 	}
-	if (!ip_address) {
-		ip_address = UpnpGetServerIpAddress();
-	}
-	if (!port) {
-		port = UpnpGetServerPort();
-	}
 
 	SampleUtil_Print("UPnP Initialized\n"
-			 "\tipaddress = %s port = %u\n",
-		ip_address ? ip_address : "{NULL}",
-		port);
+			 "\tipv4 address = %s port = %u\n"
+			 "\tipv6 address = %s port = %u\n"
+			 "\tipv6ulagua address = %s port = %u\n",
+		UpnpGetServerIpAddress(), UpnpGetServerPort(),
+		UpnpGetServerIp6Address(), UpnpGetServerPort6(),
+		UpnpGetServerUlaGuaIp6Address(), UpnpGetServerUlaGuaPort6());
 	SampleUtil_Print("Registering Control Point\n");
 	rc = UpnpRegisterClient(TvCtrlPointCallbackEventHandler,
 		&ctrlpt_handle,

--- a/upnp/sample/common/tv_ctrlpt.h
+++ b/upnp/sample/common/tv_ctrlpt.h
@@ -182,7 +182,7 @@ void TvCtrlPointVerifyTimeouts(
 
 void	TvCtrlPointPrintCommands(void);
 void*	TvCtrlPointCommandLoop(void *);
-int		TvCtrlPointStart(print_string printFunctionPtr, state_update updateFunctionPtr, int combo);
+int		TvCtrlPointStart(char* iface, state_update updateFunctionPtr, int combo);
 int		TvCtrlPointStop(void);
 int		TvCtrlPointProcessCommand(char *cmdline);
 

--- a/upnp/sample/linux/tv_combo_main.c
+++ b/upnp/sample/linux/tv_combo_main.c
@@ -38,8 +38,10 @@
 
 int main(int argc, char *argv[])
 {
+	char *iface = NULL;
 	int rc;
 	ithread_t cmdloop_thread;
+	int i = 0;
 #ifdef _WIN32
 #else
 	int sig;
@@ -47,8 +49,24 @@ int main(int argc, char *argv[])
 #endif
 	int code;
 
+	SampleUtil_Initialize(linux_print);
+	/* Parse options */
+	for (i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "-i") == 0) {
+			iface = argv[++i];
+		} else if (strcmp(argv[i], "-help") == 0) {
+			SampleUtil_Print(
+				"Usage: %s -i interface -help (this message)\n",
+				argv[0]);
+			SampleUtil_Print(
+				"\tinterface:     interface address of the control point\n"
+				"\t\te.g.: eth0\n");
+			return 1;
+		}
+	}
+
 	device_main(argc, argv);
-	rc = TvCtrlPointStart(linux_print, NULL, 1);
+	rc = TvCtrlPointStart(iface, NULL, 1);
 	if (rc != TV_SUCCESS) {
 		SampleUtil_Print("Error starting UPnP TV Control Point\n");
 		return rc;

--- a/upnp/sample/linux/tv_ctrlpt_main.c
+++ b/upnp/sample/linux/tv_ctrlpt_main.c
@@ -40,8 +40,10 @@ int main(int argc, char **argv)
 {
 	(void)argc;
 	(void)argv;
+	char *iface = NULL;
 	int rc;
 	ithread_t cmdloop_thread;
+	int i = 0;
 #ifdef _WIN32
 #else
 	int sig;
@@ -49,7 +51,23 @@ int main(int argc, char **argv)
 #endif
 	int code;
 
-	rc = TvCtrlPointStart(linux_print, NULL, 0);
+	SampleUtil_Initialize(linux_print);
+	/* Parse options */
+	for (i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "-i") == 0) {
+			iface = argv[++i];
+		} else if (strcmp(argv[i], "-help") == 0) {
+			SampleUtil_Print(
+				"Usage: %s -i interface -help (this message)\n",
+				argv[0]);
+			SampleUtil_Print(
+				"\tinterface:     interface address of the control point\n"
+				"\t\te.g.: eth0\n");
+			return 1;
+		}
+	}
+
+	rc = TvCtrlPointStart(iface, NULL, 0);
 	if (rc != TV_SUCCESS) {
 		SampleUtil_Print("Error starting UPnP TV Control Point\n");
 		return rc;


### PR DESCRIPTION
This is useful to test UPnP on specific interface (e.g. IPv6-only).
This was already possible on the device sample.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>