### PR TITLE
Fix IPv6 GENA subscription

### DIFF
--- a/upnp/src/gena/gena_ctrlpt.c
+++ b/upnp/src/gena/gena_ctrlpt.c
@@ -361,7 +361,10 @@ static int gena_subscribe(
 					? gIF_IPV6
 					: gIF_IPV6_ULA_GUA,
 				"]:",
-				LOCAL_PORT_V6,
+				(IN6_IS_ADDR_LINKLOCAL(&DestAddr6->sin6_addr) ||
+					strlen(gIF_IPV6_ULA_GUA) == 0)
+					? LOCAL_PORT_V6
+					: LOCAL_PORT_V6_ULA_GUA,
 				"/>",
 				"NT: upnp:event",
 				"TIMEOUT: Second-",

--- a/upnp/src/inc/upnpapi.h
+++ b/upnp/src/inc/upnpapi.h
@@ -221,6 +221,7 @@ extern unsigned gIF_INDEX;
 
 extern unsigned short LOCAL_PORT_V4;
 extern unsigned short LOCAL_PORT_V6;
+extern unsigned short LOCAL_PORT_V6_ULA_GUA;
 
 
 /*! NLS uuid. */


### PR DESCRIPTION
Use LOCAL_PORT_V6_ULA_GUA or LOCAL_PORT_V6 depending on the IPv6 address

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>