### PR TITLE
Added googletest and initial testsuites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,3 +475,35 @@ CONFIGURE_FILE (${CMAKE_CURRENT_SOURCE_DIR}/libupnp.pc.in ${CMAKE_CURRENT_BINARY
 INSTALL (FILES ${CMAKE_CURRENT_BINARY_DIR}/libupnp.pc
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
+
+# Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+  include_directories("${gtest_SOURCE_DIR}/include")
+endif()

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/gtest/run_test
+++ b/gtest/run_test
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+BUILD_DIR=".."
+TESTNAME=$(/usr/bin/basename -s.cpp "$1")
+/usr/bin/g++ -std=c++11 -pedantic-errors -Wall \
+-o"$TESTNAME".a \
+-I"$BUILD_DIR"/googletest-src/googletest/include \
+-I"$BUILD_DIR"/googletest-src/googlemock/include \
+-I"$BUILD_DIR" \
+-I"$BUILD_DIR"/upnp/src \
+-I"$BUILD_DIR"/upnp/inc \
+-I"$BUILD_DIR"/upnp/src/inc \
+-I"$BUILD_DIR"/upnp/src/threadutil \
+-I"$BUILD_DIR"/ixml/inc \
+-DUPNP_ENABLE_IPV6 \
+"$1" \
+"$BUILD_DIR"/lib/libgtestd.a \
+"$BUILD_DIR"/upnp/libupnp.a \
+"$BUILD_DIR"/ixml/libixml.a \
+-lpthread \
+&& ./"$TESTNAME".a

--- a/gtest/test_template.cpp
+++ b/gtest/test_template.cpp
@@ -1,0 +1,72 @@
+// This test should run, reporting no failure
+
+#include "gtest/gtest.h"
+
+// for TestSuites linked against the static C library
+extern "C" {
+    //#include "upnp.h"
+}
+
+// two macros to compare values in a range
+#define EXPECT_IN_RANGE(VAL, MIN, MAX) \
+    EXPECT_GE((VAL), (MIN));           \
+    EXPECT_LE((VAL), (MAX))
+
+#define ASSERT_IN_RANGE(VAL, MIN, MAX) \
+    ASSERT_GE((VAL), (MIN));           \
+    ASSERT_LE((VAL), (MAX))
+
+
+// simple testsuite without fixtures
+//----------------------------------
+TEST(EmptyTestSuite, empty_gtest)
+{
+}
+
+
+// testsuite with fixtures
+//------------------------
+class EmptyFixtureTestSuite : public ::testing::Test
+{
+    protected:
+    // You can remove any or all of the following functions if their bodies would
+    // be empty.
+
+    EmptyFixtureTestSuite()
+    {
+        // You can do set-up work for each test here.
+    }
+
+    ~EmptyFixtureTestSuite() override
+    {
+        // You can do clean-up work that doesn't throw exceptions here.
+    }
+
+        // If the constructor and destructor are not enough for setting up
+        // and cleaning up each test, you can define the following methods:
+
+    void SetUp() override
+    {
+        // Code here will be called immediately after the constructor (right
+        // before each test). Have attention to the uppercase 'U' of SetUp().
+    }
+
+    void TearDown() override
+    {
+        // Code here will be called immediately after each test (right
+        // before the destructor).
+    }
+
+    // Class members declared here can be used by all tests in the test suite
+    // for Foo.
+};
+
+TEST_F(EmptyFixtureTestSuite, empty_gtest_with_fixture)
+{
+}
+
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gtest/test_upnpapi.cpp
+++ b/gtest/test_upnpapi.cpp
@@ -1,0 +1,88 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+// for TestSuites needing headers linked against the static C library
+extern "C" {
+    #include "upnp.h"
+    #include "upnpapi.h"
+    #include "upnputil.h"
+}
+
+#define EXPECT_IN_RANGE(VAL, MIN, MAX) \
+    EXPECT_GE((VAL), (MIN));           \
+    EXPECT_LE((VAL), (MAX))
+
+using ::testing::MatchesRegex;
+
+
+// UpnpApi Testsuite for IP4
+//--------------------------
+class UpnpApiIPv4TestSuite: public ::testing::Test
+{
+    // Fixtures for this Testsuite
+    protected:
+    std::string interface = "ens2";
+    unsigned short PORT = 51515;
+};
+
+TEST_F(UpnpApiIPv4TestSuite, UpnpGetIfInfo)
+{
+    EXPECT_EQ(UpnpGetIfInfo(interface.c_str()), UPNP_E_SUCCESS);
+    EXPECT_STREQ(gIF_NAME, interface.c_str());
+    EXPECT_THAT(gIF_IPV4, MatchesRegex("[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}"));
+    EXPECT_STREQ(gIF_IPV6, "");
+    EXPECT_STREQ(gIF_IPV6_ULA_GUA, "");
+    EXPECT_IN_RANGE((int)gIF_INDEX, 1, 20);
+}
+
+TEST_F(UpnpApiIPv4TestSuite, UpnpInit2)
+{
+    int return_value = UpnpInit2(interface.c_str(), PORT);
+    EXPECT_EQ(return_value, UPNP_E_SUCCESS);
+}
+
+
+// UpnpApi Testsuite for IP6
+//--------------------------
+class UpnpApiIPv6TestSuite: public ::testing::Test
+{
+    // Fixtures for this Testsuite
+    protected:
+    std::string interface = "ens1";
+    unsigned short PORT = 51515;
+};
+
+TEST_F(UpnpApiIPv6TestSuite, UpnpGetIfInfo)
+{
+    EXPECT_EQ(UpnpGetIfInfo(interface.c_str()), UPNP_E_SUCCESS);
+    EXPECT_STREQ(gIF_NAME, interface.c_str());
+    EXPECT_STREQ(gIF_IPV4, "");
+    //strncpy(gIF_IPV6, "fe80::5054:ff:fe40:50f6", 24); //testing the regex
+    EXPECT_THAT(gIF_IPV6, MatchesRegex("([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4}"));
+    EXPECT_THAT(gIF_IPV6_ULA_GUA, MatchesRegex("([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4}"));
+    EXPECT_IN_RANGE((int)gIF_INDEX, 1, 20);
+}
+
+TEST_F(UpnpApiIPv6TestSuite, UpnpInit2)
+{
+    //GTEST_SKIP();
+    int return_value = UpnpInit2(interface.c_str(), PORT);
+    EXPECT_EQ(return_value, UPNP_E_SUCCESS);
+}
+
+
+// UpnpApi common Testsuite
+//-------------------------
+TEST(UpnpApiTestSuite, GetHandleInfo)
+{
+    Handle_Info **HndInfo = 0;
+    EXPECT_EQ(GetHandleInfo(0, HndInfo), HND_INVALID);
+    EXPECT_EQ(GetHandleInfo(1, HndInfo), HND_INVALID);
+    EXPECT_EQ(GetHandleInfo(NUM_HANDLE, HndInfo), HND_INVALID);
+}
+
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Download googletest from github with cmake into the project to simply
keep it up to date and to keep the project lean.

Just install with `cmake .` in `pupnp/`. It will download googletest to `pupnp/googletest-build`, `pupnp/googletest-src` and `pupnp/googletest-download` and build it:

    pupnp$ cmake .  # there is a dot
    pupnp$ make     # create the library
    pupnp$ cd googletest-build
    googletest-build$ make   # create googletest

This will create the different static linked programs in `pupnp/lib`. Use them to link your testsuites. Have a look at `pupnp/gtest/run_test`. It's a bash script. At first you should check the test environment by running the test_template.cpp. It must end without failures and output "PASSED":

    gtest$ ./run_test test_template.cpp

Because the tests are compiled you can just run them again if you don't have made changes on the tests or on the library:

    gtest$ ./test_template.a
