### PR TITLE
Fix crash in UpnpGetIfInfo

### DIFF
--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -3771,6 +3771,10 @@ int UpnpGetIfInfo(const char *IfName)
 			(!(ifa->ifa_flags & IFF_MULTICAST))) {
 			continue;
 		}
+		/* Entries may be provided for non-existent addresses. */
+		if (ifa->ifa_addr == NULL) {
+			continue;
+		}
 		if (ifname_found == 0) {
 			/* We have found a valid interface name. Keep it. */
 			memset(gIF_NAME, 0, sizeof(gIF_NAME));


### PR DESCRIPTION
Per getifaddrs documentation, the ifa_addr field of an ifaddrs structure
can be null. In a real world example, an entry may be provided for the
non-existent hardware address of a tunnel device. This behavior was
observed with the netlink based getifaddrs implementation in glibc.