### PR TITLE
Handle interfaces without address

### DIFF
--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -3763,10 +3763,11 @@ int UpnpGetIfInfo(const char *IfName)
 	}
 	/* cycle through available interfaces and their addresses. */
 	for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
-		/* Skip LOOPBACK interfaces, DOWN interfaces and interfaces that
-		 */
-		/* don't support MULTICAST. */
-		if ((ifa->ifa_flags & IFF_LOOPBACK) ||
+		/* Skip LOOPBACK interfaces, DOWN interfaces, */
+		/* interfaces without address (e.g. bonded)*/
+		/* and interfaces that don't support MULTICAST. */
+		if (!ifa->ifa_addr ||
+		        (ifa->ifa_flags & IFF_LOOPBACK) ||
 			(!(ifa->ifa_flags & IFF_UP)) ||
 			(!(ifa->ifa_flags & IFF_MULTICAST))) {
 			continue;


### PR DESCRIPTION
I got a crash on gerbera startup because at least one interface did not have `ifa_addr` set.

The reason is quite simple: they are the physical interfaces which are part of my channel 😄 
```
2: eth1: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc fq_codel master bond0 state UP group default qlen 1000
    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
3: eth0: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc fq_codel master bond0 state UP group default qlen 1000
    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
4: bond0: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
```