### PR TITLE
Expose ExtraHeaderList in the ActionRequest interface

### DIFF
--- a/upnp/generator/generator.c
+++ b/upnp/generator/generator.c
@@ -966,7 +966,7 @@ int main(int argc, const char *argv[])
 		if (!fp) {
 			continue;
 		}
-		printf("Writting %s ... ", c[i].header);
+		printf("Writing %s ... ", c[i].header);
 		write_header(fp, c + i);
 		fclose(fp);
 		printf("done!\n");
@@ -975,7 +975,7 @@ int main(int argc, const char *argv[])
 		if (!fp) {
 			continue;
 		}
-		printf("Writting %s ... ", c[i].source);
+		printf("Writing %s ... ", c[i].source);
 		write_source(fp, c + i);
 		fclose(fp);
 		printf("done!\n");

--- a/upnp/generator/generator.c
+++ b/upnp/generator/generator.c
@@ -35,6 +35,7 @@ static struct s_Member UpnpActionRequest_members[] = {
 		struct sockaddr_storage,
 		"UpnpInet.h"),
 	INIT_MEMBER(Os, TYPE_STRING, 0, 0),
+	INIT_MEMBER(ExtraHeadersList, TYPE_LIST, 0, 0),
 };
 
 static struct s_Member UpnpDiscovery_members[] = {

--- a/upnp/inc/UpnpActionRequest.h
+++ b/upnp/inc/UpnpActionRequest.h
@@ -17,6 +17,7 @@
 #include "UpnpString.h"
 #include "ixml.h"
 #include "UpnpInet.h"
+#include "list.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -142,6 +143,13 @@ EXPORT_SPEC int UpnpActionRequest_strcpy_Os(UpnpActionRequest *p, const char *s)
 EXPORT_SPEC int UpnpActionRequest_strncpy_Os(UpnpActionRequest *p, const char *s, size_t n); 
 /*! UpnpActionRequest_clear_Os */
 EXPORT_SPEC void UpnpActionRequest_clear_Os(UpnpActionRequest *p); 
+
+/*! UpnpActionRequest_get_ExtraHeadersList */
+EXPORT_SPEC const UpnpListHead *UpnpActionRequest_get_ExtraHeadersList(const UpnpActionRequest *p);
+/*! UpnpActionRequest_set_ExtraHeadersList */
+EXPORT_SPEC int UpnpActionRequest_set_ExtraHeadersList(UpnpActionRequest *p, const UpnpListHead *q);
+/*! UpnpActionRequest_add_to_list_ExtraHeadersList */
+EXPORT_SPEC void UpnpActionRequest_add_to_list_ExtraHeadersList(UpnpActionRequest *p, UpnpListHead *head);
 
 #ifdef __cplusplus
 }

--- a/upnp/src/api/UpnpActionRequest.c
+++ b/upnp/src/api/UpnpActionRequest.c
@@ -28,6 +28,7 @@ struct s_UpnpActionRequest
 	IXML_Document * m_SoapHeader;
 	struct sockaddr_storage m_CtrlPtIPAddr;
 	UpnpString *m_Os;
+	UpnpListHead m_ExtraHeadersList;
 };
 
 UpnpActionRequest *UpnpActionRequest_new()
@@ -47,6 +48,7 @@ UpnpActionRequest *UpnpActionRequest_new()
 	/*p->m_SoapHeader = 0;*/
 	/* memset(&p->m_CtrlPtIPAddr, 0, sizeof (struct sockaddr_storage)); */
 	p->m_Os = UpnpString_new();
+	UpnpListInit(&p->m_ExtraHeadersList);
 
 	return (UpnpActionRequest *)p;
 }
@@ -57,6 +59,7 @@ void UpnpActionRequest_delete(UpnpActionRequest *q)
 
 	if (!p) return;
 
+	UpnpListInit(&p->m_ExtraHeadersList);
 	UpnpString_delete(p->m_Os);
 	p->m_Os = 0;
 	memset(&p->m_CtrlPtIPAddr, 0, sizeof (struct sockaddr_storage));
@@ -93,6 +96,7 @@ int UpnpActionRequest_assign(UpnpActionRequest *p, const UpnpActionRequest *q)
 		ok = ok && UpnpActionRequest_set_SoapHeader(p, UpnpActionRequest_get_SoapHeader(q));
 		ok = ok && UpnpActionRequest_set_CtrlPtIPAddr(p, UpnpActionRequest_get_CtrlPtIPAddr(q));
 		ok = ok && UpnpActionRequest_set_Os(p, UpnpActionRequest_get_Os(q));
+		ok = ok && UpnpActionRequest_set_ExtraHeadersList(p, UpnpActionRequest_get_ExtraHeadersList(q));
 	}
 
 	return ok;
@@ -369,5 +373,23 @@ int UpnpActionRequest_strncpy_Os(UpnpActionRequest *p, const char *s, size_t n)
 void UpnpActionRequest_clear_Os(UpnpActionRequest *p)
 {
 	UpnpString_clear(p->m_Os);
+}
+
+const UpnpListHead *UpnpActionRequest_get_ExtraHeadersList(const UpnpActionRequest *p)
+{
+	return &p->m_ExtraHeadersList;
+}
+
+int UpnpActionRequest_set_ExtraHeadersList(UpnpActionRequest *p, const UpnpListHead *q)
+{
+	p->m_ExtraHeadersList = *q;
+
+	return 1;
+}
+
+void UpnpActionRequest_add_to_list_ExtraHeadersList(UpnpActionRequest *p, struct UpnpListHead *head)
+{
+	UpnpListHead *list = &p->m_ExtraHeadersList;
+	UpnpListInsert(list, UpnpListEnd(list), head);
 }
 

--- a/upnp/src/inc/httpparser.h
+++ b/upnp/src/inc/httpparser.h
@@ -420,6 +420,36 @@ parse_status_t parser_append(
 	http_parser_t *parser, const char *buf, size_t buf_length);
 
 /************************************************************************
+* Function: parser_get_unknown_headers
+*
+* Parameters:
+*	IN http_message_t req ;		HTTP request
+*	INOUT UpnpListHead list ;   Extra headers list
+*
+* Description: Append unknown HTTP headers to the list.
+*
+* Returns:
+*	HTTP_OK
+*	HTTP_INTERNAL_SERVER_ERROR
+************************************************************************/
+
+int parser_get_unknown_headers(http_message_t *req, UpnpListHead *list);
+
+/************************************************************************
+* Function: free_http_headers_list
+*
+* Parameters:
+*	IN UpnpListHead list ;   Extra headers list
+*
+* Description: Free all extra headers nodes in the given list.
+*
+* Returns:
+*	HTTP_OK
+*	HTTP_INTERNAL_SERVER_ERROR
+************************************************************************/
+void free_http_headers_list(UpnpListHead *list);
+
+/************************************************************************
  * Function: matchstr
  *
  * Parameters:

--- a/upnp/src/soap/soap_device.c
+++ b/upnp/src/soap/soap_device.c
@@ -432,6 +432,13 @@ static void handle_invoke_action(
 			action, hdr_value.buf, hdr_value.length);
 	}
 
+	if ((err_code = parser_get_unknown_headers(request,
+		     (UpnpListHead *)UpnpActionRequest_get_ExtraHeadersList(
+			     action))) != HTTP_OK) {
+		err_code = SOAP_ACTION_FAILED;
+		goto error_handler;
+	}
+
 	UpnpPrintf(UPNP_INFO, SOAP, __FILE__, __LINE__, "Calling Callback\n");
 	soap_info->callback(
 		UPNP_CONTROL_ACTION_REQUEST, action, soap_info->cookie);
@@ -460,6 +467,8 @@ error_handler:
 	ixmlDocument_free(actionResultDoc);
 	ixmlDocument_free(actionRequestDoc);
 	ixmlFreeDOMString(act_node);
+	free_http_headers_list(
+		(UpnpListHead *)UpnpActionRequest_get_ExtraHeadersList(action));
 	/* restore */
 	action_name.buf[action_name.length] = save_char;
 	if (err_code != 0)


### PR DESCRIPTION
This PR exposes unrecognized headers in the `UpnpActionRequest` interface
Api users might want to process some http headers that are not recognized by the pupnp http server. A similar behavior is already implemented for the upnp http io callbacks in the `FileInfo` interface.