### PR TITLE
Changed to use cxx-compiler

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -16,14 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install build tools
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y ninja-build
-
       - name: Build
         run: |
-          cmake -G Ninja -DDOWNLOAD_AND_BUILD_DEPS=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=${{ matrix.conf }} -S . -B build
+          cmake -DDOWNLOAD_AND_BUILD_DEPS=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=${{ matrix.conf }} -S . -B build
           cmake --build build
 
       - name: Test

--- a/upnp/CMakeLists.txt
+++ b/upnp/CMakeLists.txt
@@ -82,6 +82,8 @@ if (uuid)
 	)
 endif()
 
+set_source_files_properties (${UPNP_SOURCES} PROPERTIES LANGUAGE CXX)
+
 add_library (upnp_shared SHARED
 	${UPNP_SOURCES}
 )

--- a/upnp/sample/CMakeLists.txt
+++ b/upnp/sample/CMakeLists.txt
@@ -1,67 +1,76 @@
-IF (client)
-	ADD_EXECUTABLE (tv_ctrlpt
+set_source_files_properties (common/sample_util.c
+	common/tv_ctrlpt.c
+	common/tv_device.c
+	linux/tv_combo_main.c
+	linux/tv_ctrlpt_main.c
+	linux/tv_device_main.c
+	PROPERTIES LANGUAGE CXX
+)
+
+if (client)
+	add_executable (tv_ctrlpt
 		common/sample_util.c
 		common/tv_ctrlpt.c
 		linux/tv_ctrlpt_main.c
 	)
 
-	TARGET_INCLUDE_DIRECTORIES (tv_ctrlpt
+	target_include_directories (tv_ctrlpt
 		PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/common
 		PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/common
 	)
 
-	TARGET_LINK_LIBRARIES (tv_ctrlpt
+	target_link_libraries (tv_ctrlpt
 		upnp_shared
 	)
 
-	INSTALL (TARGETS tv_ctrlpt
+	install (TARGETS tv_ctrlpt
 		DESTINATION ${CMAKE_INSTALL_BINDIR}
 	)
-ENDIF (client)
+endif()
 
-IF (client AND device)
-	ADD_EXECUTABLE (tv_combo
+if (client AND device)
+	add_executable (tv_combo
 		common/sample_util.c
 		common/tv_ctrlpt.c
 		common/tv_device.c
 		linux/tv_combo_main.c
 	)
 
-	TARGET_INCLUDE_DIRECTORIES (tv_combo
+	target_include_directories (tv_combo
 		PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/common
 		PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/common
 	)
 
-	TARGET_LINK_LIBRARIES (tv_combo
+	target_link_libraries (tv_combo
 		upnp_shared
 	)
 
-	INSTALL (TARGETS tv_combo
+	install (TARGETS tv_combo
 		DESTINATION ${CMAKE_INSTALL_BINDIR}
 	)
-ENDIF (client AND device)
+endif()
 
-IF (device)
-	ADD_EXECUTABLE (tv_device
+if (device)
+	add_executable (tv_device
 		common/sample_util.c
 		common/tv_device.c
 		linux/tv_device_main.c
 	)
 
-	TARGET_INCLUDE_DIRECTORIES (tv_device
+	target_include_directories (tv_device
 		PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/common
 		PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/common
 	)
 
-	TARGET_LINK_LIBRARIES (tv_device
+	target_link_libraries (tv_device
 		upnp_shared
 	)
 
-	INSTALL (TARGETS tv_device
+	install (TARGETS tv_device
 		DESTINATION ${CMAKE_INSTALL_BINDIR}
 	)
 
-	INSTALL (DIRECTORY web/
+	install (DIRECTORY web/
 		DESTINATION ${CMAKE_INSTALL_DATADIR}/upnp
 	)
-ENDIF (device)
+endif()

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -1,3 +1,10 @@
+set_source_files_properties (test_init.c
+	test_list.c
+	test_log.c
+	test_url.c
+	PROPERTIES LANGUAGE CXX
+)
+
 if (WIN32)
 	set (TEST_ENV "PATH=$<TARGET_FILE_DIR:upnp_shared>\;$<TARGET_FILE_DIR:ixml_shared>\;")
 	string (APPEND TEST_ENV "$<TARGET_FILE_DIR:Threads::Threads>\;")


### PR DESCRIPTION
I'm not sure if autotools just decided over your head to compile .c files as C, but I get errors with cpp-compiler. Easiest would be to just rename the files to .cpp or .cxx to let the system know what to do.

Related; #255