### PR TITLE
CMakeLists.txt missing in official 1.14.1 and 1.14.2 tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,15 @@ SUBDIRS = \
 	docs
 
 EXTRA_DIST = \
+	CMakeLists.txt \
+	CmDaB.cmake \
+	IXML.cmake.in \
+	UPNP.cmake.in \
+	ixml/CMakeLists.txt \
+	ixml/test/CMakeLists.txt \
+	upnp/CMakeLists.txt \
+	upnp/test/CMakeLists.txt \
+	upnp/sample/CMakeLists.txt \
 	docs/Doxyfile \
 	libupnp.pc.in \
 	libupnp.spec \


### PR DESCRIPTION
Hopefully closes #280