### PR TITLE
CMakeLists.txt: add UPNP_BUILD_{SHARED,STATIC} options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ if (WIN32)
 	set (STATIC_POSTFIX s)
 endif()
 
+option (UPNP_BUILD_SHARED "Build shared libraries" ON)
+option (UPNP_BUILD_STATIC "Build static libraries" ON)
 option (BUILD_TESTING "Run Tests after compile" ON)
 
 

--- a/ixml/CMakeLists.txt
+++ b/ixml/CMakeLists.txt
@@ -16,82 +16,88 @@ set (IXML_SOURCES
 	src/nodeList.c
 )
 
-add_library (ixml_shared SHARED
-	${IXML_SOURCES}
-)
+if (UPNP_BUILD_SHARED)
+	add_library (ixml_shared SHARED
+		${IXML_SOURCES}
+	)
 
-add_library (IXML::Shared ALIAS ixml_shared)
+	add_library (IXML::Shared ALIAS ixml_shared)
 
-target_compile_definitions (ixml_shared
-	PRIVATE $<$<BOOL:${script_support}>:IXML_HAVE_SCRIPTSUPPORT>
-	PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
-	PUBLIC $<$<BOOL:${MSVC}>:UPNP_USE_MSVCPP>
-	PUBLIC $<$<BOOL:${MSVC}>:LIBUPNP_EXPORTS>
-)
+	target_compile_definitions (ixml_shared
+		PRIVATE $<$<BOOL:${script_support}>:IXML_HAVE_SCRIPTSUPPORT>
+		PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
+		PUBLIC $<$<BOOL:${MSVC}>:UPNP_USE_MSVCPP>
+		PUBLIC $<$<BOOL:${MSVC}>:LIBUPNP_EXPORTS>
+	)
 
-target_include_directories (ixml_shared
-	PRIVATE ${PUPNP_BINARY_DIR}/
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
-	PUBLIC $<BUILD_INTERFACE:${PUPNP_SOURCE_DIR}/upnp/inc/>
-)
+	target_include_directories (ixml_shared
+		PRIVATE ${PUPNP_BINARY_DIR}/
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
+		PUBLIC $<BUILD_INTERFACE:${PUPNP_SOURCE_DIR}/upnp/inc/>
+	)
 
-list (APPEND IXML_HEADERS
-	inc/ixml.h
-	inc/ixmldebug.h
-)
+	list (APPEND IXML_HEADERS
+		inc/ixml.h
+		inc/ixmldebug.h
+	)
 
-set_target_properties (ixml_shared PROPERTIES
-	OUTPUT_NAME ixml
-	EXPORT_NAME IXML::Shared
-	VERSION ${IXML_VERSION}
-	SOVERSION ${IXML_VERSION_MAJOR}
-	PUBLIC_HEADER "${IXML_HEADERS}"
-)
+	set_target_properties (ixml_shared PROPERTIES
+		OUTPUT_NAME ixml
+		EXPORT_NAME IXML::Shared
+		VERSION ${IXML_VERSION}
+		SOVERSION ${IXML_VERSION_MAJOR}
+		PUBLIC_HEADER "${IXML_HEADERS}"
+	)
 
-install (TARGETS ixml_shared
-	EXPORT IXML
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
-	PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
-)
-
-add_library (ixml_static STATIC
-	${IXML_SOURCES}
-)
-
-add_library (IXML::Static ALIAS ixml_static)
-
-set_target_properties (ixml_static PROPERTIES
-	OUTPUT_NAME ixml${STATIC_POSTFIX}
-	EXPORT_NAME IXML::Static
-)
-
-target_compile_definitions (ixml_static
-	PRIVATE $<$<BOOL:${script_support}>:IXML_HAVE_SCRIPTSUPPORT>
-	PUBLIC UPNP_STATIC_LIB
-	PUBLIC $<$<BOOL:${MSVC}>:UPNP_USE_MSVCPP>
-	PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
-)
-
-if (script_support)
-	target_compile_definitions (ixml_static
-		PRIVATE IXML_HAVE_SCRIPTSUPPORT
+	install (TARGETS ixml_shared
+		EXPORT IXML
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
+		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
 	)
 endif()
 
-target_include_directories (ixml_static
-	PRIVATE ${PUPNP_BINARY_DIR}/
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
-	PUBLIC $<BUILD_INTERFACE:${PUPNP_SOURCE_DIR}/upnp/inc/>
-)
+if (UPNP_BUILD_STATIC)
+	add_library (ixml_static STATIC
+		${IXML_SOURCES}
+	)
 
-install (TARGETS ixml_static
-	EXPORT IXML
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
-)
+	add_library (IXML::Static ALIAS ixml_static)
+
+	set_target_properties (ixml_static PROPERTIES
+		OUTPUT_NAME ixml${STATIC_POSTFIX}
+		EXPORT_NAME IXML::Static
+		PUBLIC_HEADER "${IXML_HEADERS}"
+	)
+
+	target_compile_definitions (ixml_static
+		PRIVATE $<$<BOOL:${script_support}>:IXML_HAVE_SCRIPTSUPPORT>
+		PUBLIC UPNP_STATIC_LIB
+		PUBLIC $<$<BOOL:${MSVC}>:UPNP_USE_MSVCPP>
+		PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
+	)
+
+	if (script_support)
+		target_compile_definitions (ixml_static
+			PRIVATE IXML_HAVE_SCRIPTSUPPORT
+		)
+	endif()
+
+	target_include_directories (ixml_static
+		PRIVATE ${PUPNP_BINARY_DIR}/
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
+		PUBLIC $<BUILD_INTERFACE:${PUPNP_SOURCE_DIR}/upnp/inc/>
+	)
+
+	install (TARGETS ixml_static
+		EXPORT IXML
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
+		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
+	)
+endif()
 
 install (EXPORT IXML
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/IXML

--- a/upnp/CMakeLists.txt
+++ b/upnp/CMakeLists.txt
@@ -83,29 +83,6 @@ if (uuid)
 	)
 endif()
 
-add_library (upnp_shared SHARED
-	${UPNP_SOURCES}
-)
-
-add_library (UPNP::Shared ALIAS upnp_shared)
-
-set_target_properties (upnp_shared PROPERTIES
-	WINDOWS_EXPORT_ALL_SYMBOLS TRUE
-)
-
-target_compile_definitions (upnp_shared
-	PRIVATE $<$<CONFIG:Debug>:STATS>
-	PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
-)
-
-target_include_directories (upnp_shared
-	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/threadutil/
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
-	PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/>
-	PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/upnp/inc/>
-)
-
 list (APPEND UPNP_HEADERS
 	inc/Callback.h
 	inc/ithread.h
@@ -137,100 +114,129 @@ if (tools)
 	)
 endif()
 
-set_target_properties (upnp_shared PROPERTIES
-	OUTPUT_NAME ${WIN_PREFIX}upnp
-	EXPORT_NAME UPNP::Shared
-	VERSION ${UPNP_VERSION}
-	SOVERSION ${UPNP_VERSION_MAJOR}
-	PUBLIC_HEADER "${UPNP_HEADERS}"
-)
+if (UPNP_BUILD_SHARED)
+	add_library (upnp_shared SHARED
+		${UPNP_SOURCES}
+	)
 
-target_compile_definitions (upnp_shared
-	PRIVATE $<$<CONFIG:Debug>:STATS>
-	PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
-)
+	add_library (UPNP::Shared ALIAS upnp_shared)
 
-target_include_directories (upnp_shared
-	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/threadutil/
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
-	PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/>
-	PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/upnp/inc/>
-)
+	set_target_properties (upnp_shared PROPERTIES
+		WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+	)
 
-if (WIN32)
+	target_compile_definitions (upnp_shared
+		PRIVATE $<$<CONFIG:Debug>:STATS>
+		PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
+	)
+
+	target_include_directories (upnp_shared
+		PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/threadutil/
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
+		PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/>
+		PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/upnp/inc/>
+	)
+
+	set_target_properties (upnp_shared PROPERTIES
+		OUTPUT_NAME ${WIN_PREFIX}upnp
+		EXPORT_NAME UPNP::Shared
+		VERSION ${UPNP_VERSION}
+		SOVERSION ${UPNP_VERSION_MAJOR}
+		PUBLIC_HEADER "${UPNP_HEADERS}"
+	)
+
+	target_compile_definitions (upnp_shared
+		PRIVATE $<$<CONFIG:Debug>:STATS>
+		PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
+	)
+
+	target_include_directories (upnp_shared
+		PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/threadutil/
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
+		PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/>
+		PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/upnp/inc/>
+	)
+
+	if (WIN32)
+		target_link_libraries (upnp_shared
+			PRIVATE ws2_32
+			PRIVATE iphlpapi
+		)
+	endif()
+
 	target_link_libraries (upnp_shared
-		PRIVATE ws2_32
-		PRIVATE iphlpapi
+		PUBLIC ixml_shared
+		PUBLIC Threads::Shared
+	)
+
+	if (UPNP_ENABLE_OPEN_SSL)
+		target_link_libraries (upnp_shared
+			PRIVATE OpenSSL::SSL
+		)
+	endif()
+
+	install (TARGETS upnp_shared
+		EXPORT UPNP
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
+		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
 	)
 endif()
 
-target_link_libraries (upnp_shared
-	PUBLIC ixml_shared
-	PUBLIC Threads::Shared
-)
-
-if (UPNP_ENABLE_OPEN_SSL)
-	target_link_libraries (upnp_shared
-		PRIVATE OpenSSL::SSL
+if (UPNP_BUILD_STATIC)
+	add_library (upnp_static STATIC
+		${UPNP_SOURCES}
 	)
-endif()
 
-install (TARGETS upnp_shared
-	EXPORT UPNP
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
-	PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
-)
+	add_library (UPNP::Static ALIAS upnp_static)
 
-add_library (upnp_static STATIC
-	${UPNP_SOURCES}
-)
+	target_compile_definitions (upnp_static
+		PRIVATE UPNP_STATIC_LIB
+		PRIVATE $<$<CONFIG:Debug>:STATS>
+		PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
+	)
 
-add_library (UPNP::Static ALIAS upnp_static)
+	target_include_directories (upnp_static
+		PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/threadutil/
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
+		PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
+		PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/>
+		PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/upnp/inc/>
+	)
 
-target_compile_definitions (upnp_static
-	PRIVATE UPNP_STATIC_LIB
-	PRIVATE $<$<CONFIG:Debug>:STATS>
-	PUBLIC $<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>
-)
+	if (WIN32)
+		target_link_libraries (upnp_static
+			INTERFACE ws2_32
+			INTERFACE iphlpapi
+		)
+	endif()
 
-target_include_directories (upnp_static
-	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/threadutil/
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/inc/>
-	PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/>
-	PUBLIC $<BUILD_INTERFACE:${PUPNP_BINARY_DIR}/upnp/inc/>
-)
+	set_target_properties (upnp_static PROPERTIES
+		OUTPUT_NAME ${WIN_PREFIX}upnp${STATIC_POSTFIX}
+		EXPORT_NAME UPNP::Static
+		PUBLIC_HEADER "${UPNP_HEADERS}"
+	)
 
-if (WIN32)
 	target_link_libraries (upnp_static
-		INTERFACE ws2_32
-		INTERFACE iphlpapi
+		PUBLIC ixml_static
+		PUBLIC Threads::Static
+	)
+
+	if (UPNP_ENABLE_OPEN_SSL)
+		target_link_libraries (upnp_static
+			PRIVATE OpenSSL::SSL
+		)
+	endif()
+
+	install (TARGETS upnp_static
+		EXPORT UPNP
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
+		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
 	)
 endif()
-
-set_target_properties (upnp_static PROPERTIES
-	OUTPUT_NAME ${WIN_PREFIX}upnp${STATIC_POSTFIX}
-	EXPORT_NAME UPNP::Static
-)
-
-target_link_libraries (upnp_static
-	PUBLIC ixml_static
-	PUBLIC Threads::Static
-)
-
-if (UPNP_ENABLE_OPEN_SSL)
-	target_link_libraries (upnp_static
-		PRIVATE OpenSSL::SSL
-	)
-endif()
-
-install (TARGETS upnp_static
-	EXPORT UPNP
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/upnp
-)
 
 install (EXPORT UPNP
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/UPNP


### PR DESCRIPTION
Building shared libraries are not always possible as some embedded toolchains only support static linking so add options to build shared or static libraries and while at it install headers when building the static libraries

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>