### PR TITLE
upnp/inc/UpnpLog.h: include stdarg.h

### DIFF
--- a/upnp/inc/UpnpLog.h
+++ b/upnp/inc/UpnpLog.h
@@ -40,6 +40,7 @@
 
 #include "UpnpGlobal.h" /* for UPNP_INLINE */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
Fix the following build failure:

```
In file included from /home/fabrice/br-test-pkg/bootlin-armv7m-uclibc/build/libupnp-8427b086494e7486864c96d38dfffdea2279956b/upnp/src/api/UpnpLog.cpp:6:
/home/fabrice/br-test-pkg/bootlin-armv7m-uclibc/build/libupnp-8427b086494e7486864c96d38dfffdea2279956b/upnp/inc/UpnpLog.h:142:17: error: ‘va_list’ has not been declared
  142 |                 va_list argList);
      |                 ^~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>