### PR TITLE
Mac/Win unification

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -47,6 +47,9 @@ jobs:
         run: |
           cd build
           ctest --output-on-failure
+          cd ..
+      - name: Debug output
+        run: cmake -DBUILD_DIR=build -P cmake/post-test.cmake
   # Windows builds
   windows:
     name: Build (${{ matrix.os }})  - ${{ matrix.conf }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2016, windows-2019]
+        os: [windows-2016, windows-2019, macos-latest]
         conf: [Debug, Release]
       fail-fast: false
     steps:
@@ -65,39 +65,6 @@ jobs:
           -B build
           -DCMAKE_BUILD_TYPE=${{ matrix.conf }}
           -DBUILD_TESTING=ON
-          -DDOWNLOAD_AND_BUILD_DEPS=ON
-          ${{ env.cmake_extra_flags }}
-      - name: Build
-        run: cmake --build build --config ${{ matrix.conf }}
-      - name: Test Debug
-        if: ${{ matrix.conf == 'Debug' }}
-        run: |
-          cd build
-          ctest --output-on-failure -C ${{ matrix.conf }}
-          type upnp/test/test_init.log
-      - name: Test Release
-        if: ${{ matrix.conf == 'Release' }}
-        run: |
-          cd build
-          ctest --output-on-failure -C ${{ matrix.conf }}
-  # Macos builds
-  macos:
-    name: Build (${{ matrix.os }}) - ${{ matrix.conf }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest] # macos-10.15, macos-11.0
-        conf: [Debug, Release]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure
-        run: >
-          cmake
-          -S .
-          -B build
-          -DBUILD_TESTING=ON
-          -DCMAKE_BUILD_TYPE=${{ matrix.conf }}
           -DDOWNLOAD_AND_BUILD_DEPS=ON
           ${{ env.cmake_extra_flags }}
       - name: Build
@@ -105,7 +72,9 @@ jobs:
       - name: Test
         run: |
           cd build
-          ctest --output-on-failure --C ${{ matrix.conf }}
+          ctest --output-on-failure -C ${{ matrix.conf }}
+          cd ..
+          cmake -DBUILD_DIR=build -P cmake/post-test.cmake
   # Linux sanitizer builds
   build_asan:
     name: Sanitizer build (ubuntu-20.04) - ${{ matrix.tool }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -74,7 +74,8 @@ jobs:
           cd build
           ctest --output-on-failure -C ${{ matrix.conf }}
           cd ..
-          cmake -DBUILD_DIR=build -P cmake/post-test.cmake
+      - name: Debug output
+        run: cmake -DBUILD_DIR=build -P cmake/post-test.cmake
   # Linux sanitizer builds
   build_asan:
     name: Sanitizer build (ubuntu-20.04) - ${{ matrix.tool }}

--- a/cmake/post-test.cmake
+++ b/cmake/post-test.cmake
@@ -1,0 +1,4 @@
+if (EXISTS ${BUILD_DIR}/upnp/test/test_init.log)
+	file (READ ${BUILD_DIR}/upnp/test/test_init.log logdata)
+	message (${logdata})
+endif()


### PR DESCRIPTION
It worked when I let cmake print the logfile. Now there is an additional chapter wíth the output, which also is populated in releasebuilds. Maybe it doesn't help, but useless information vs. having a deactivated tab on the results saves one more line.