### PR TITLE
Dont call miniserver callbacks for failed hosts

### DIFF
--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -326,6 +326,9 @@ static int dispatch_request(
         host_port[min_size] = 0;
         if (host_validate_callback) {
                 rc = host_validate_callback(host_port, cookie);
+                if (rc == UPNP_E_BAD_HTTPMSG) {
+                        goto ExitFunction;
+                }
         } else if (!host_header_is_numeric(p, host_port, min_size)) {
                 int allowLiteralHostRedirection =
                         UpnpLib_get_allowLiteralHostRedirection(p);


### PR DESCRIPTION
When we implemented validation in Gerbera[0], I noticed that even if our
callback returns UPNP_E_BAD_HTTPMSG the request still get processed and
not dropped as expected.

Practically that means all hosts are valid if you have a validation
callback set :(

0. https://github.com/gerbera/gerbera/pull/2365
