### PR TITLE
windows: Avoid implicit declarations of gettimeofday()

### DIFF
--- a/upnp/src/threadutil/ThreadPool.h
+++ b/upnp/src/threadutil/ThreadPool.h
@@ -54,8 +54,8 @@ struct timezone
         int tz_minuteswest; /* minutes W of Greenwich */
         int tz_dsttime; /* type of dst correction */
 };
-int gettimeofday(struct timeval *tv, struct timezone *tz);
 #endif
+int gettimeofday(struct timeval *tv, struct timezone *tz);
 #else /* _WIN32 */
 #include <sys/param.h>
 #include <sys/time.h> /* for gettimeofday() */


### PR DESCRIPTION
This adjusts the ifdefs added in 421d5d2875a639b7c037ceadb8eec75d70d5346e (CC @ePirat).

In mingw headers, both `time.h` and `sys/time.h` define `struct timezone` and `_TIMEZONE_DEFINED` - however only one of them, `sys/time.h`, define `gettimeofday`. Thus, if `time.h` had been included before, we'd have `_TIMEZONE_DEFINED` defined, and we'd omit our own declaration of the `gettimeofday` function too, leading to calls to an undeclared function.

(If the actual `sys/time.h` header is included, its declaration of the `gettimeofday` function does conflict with both the declaration and the definition of upnp's `gettimeofday`, due to details like missing the `restrict` attribute on pointers. But that issue already existed and is unaffected by this patch.)

Since Clang 15 (which still is under development, so this may still change before it's released) [1], implicit function declarations are a hard error by default, when building code in C99 mode (or newer).

[1] https://github.com/llvm/llvm-project/commit/7d644e1215b376ec5e915df9ea2eeb56e2d94626