### PR TITLE
Remove windows-2016 build

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2016, windows-2019, macos-latest]
+        os: [windows-2019, windows-latest, macos-latest]
         conf: [Debug, Release]
       fail-fast: false
     steps:


### PR DESCRIPTION
[Windows-2016 environment will be removed on March 15, 2022](https://github.com/actions/virtual-environments/issues/4312)