### PR TITLE
miniserver: Don't initialize sockets for invalid IPs

### DIFF
--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -833,7 +833,10 @@ static int init_socket_suff(UpnpLib *p,
                 goto error;
                 break;
         }
-        inet_pton(domain, text_addr, addr);
+
+        if (inet_pton(domain, text_addr, addr) <= 0)
+            goto error;
+
         s->fd = socket(domain, SOCK_STREAM, 0);
         if (s->fd == INVALID_SOCKET) {
                 strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);


### PR DESCRIPTION
`init_socket_stuff` was ignoring `inet_pton`'s return value causing
invalid IPs being seen as valid which caused bad calls to `bind` and
`listen` further in the code path.

Invalid `bind`s were frequents for interfaces providing only one IP
protocol version (IPv4 or v6). In those cases, `gIF_IPV4` or `gIF_IPV4`
were left to their default values (an empty string) causing `inet_pton`
to fail silently without aborting the socket opening and binding...

Refs #195