### PR TITLE
miniserver: Don't initialize sockets for invalid IPs

### DIFF
--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -764,7 +764,10 @@ static int init_socket_suff(
 		goto error;
 		break;
 	}
-	inet_pton(domain, text_addr, addr);
+
+	if (inet_pton(domain, text_addr, addr) <= 0)
+		goto error;
+
 	s->fd = socket(domain, SOCK_STREAM, 0);
 	if (s->fd == INVALID_SOCKET) {
 		strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);


### PR DESCRIPTION
This is a backport of 447de4e5efdbbd8c1d51cf9ba7207d4e5310e901 for 1.14.13