### PR TITLE
Clean up after failed initialization.

### DIFF
--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -511,6 +511,10 @@ int UpnpInit2(const char *IfName, unsigned short DestPort)
 		goto exit_function;
 	}
 
+	/* Set the UpnpSdkInit flag to 1 to indicate we're successfully
+	 * initialized. */
+	UpnpSdkInit = 1;
+
 	/* Perform initialization preamble. */
 	retVal = UpnpInitPreamble();
 	if (retVal != UPNP_E_SUCCESS) {
@@ -531,18 +535,16 @@ int UpnpInit2(const char *IfName, unsigned short DestPort)
 		goto exit_function;
 	}
 
-	/* Set the UpnpSdkInit flag to 1 to indicate we're successfully
-	 * initialized. */
-	UpnpSdkInit = 1;
-
 	/* Finish initializing the SDK. */
 	retVal = UpnpInitStartServers(DestPort);
 	if (retVal != UPNP_E_SUCCESS) {
-		UpnpSdkInit = 0;
 		goto exit_function;
 	}
 
 exit_function:
+	if (retVal != UPNP_E_SUCCESS) {
+		UpnpFinish();
+	}
 	ithread_mutex_unlock(&gSDKInitMutex);
 
 	return retVal;

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -542,7 +542,7 @@ int UpnpInit2(const char *IfName, unsigned short DestPort)
 	}
 
 exit_function:
-	if (retVal != UPNP_E_SUCCESS) {
+	if (retVal != UPNP_E_SUCCESS && retVal != UPNP_E_INIT) {
 		UpnpFinish();
 	}
 	ithread_mutex_unlock(&gSDKInitMutex);


### PR DESCRIPTION
Some initialization failures (such as failure in `UpnpGetIfInfo`) would leave resources like thread pools initialized. This change ensures if `UpnpInit2` fails, we call `UpnpFinish` before returning to clean up those resources.

To ensure `UpnpFinish` is effective in this case, we set `UpnpSdkInit` to 1 near the beginning of `UpnpInit2`.