### PR TITLE
miniserver: fix busy loop on socket error

### DIFF
--- a/upnp/src/inc/ssdplib.h
+++ b/upnp/src/inc/ssdplib.h
@@ -239,8 +239,10 @@ int ssdp_request_type(
 
 /*!
  * \brief This function reads the data from the ssdp socket.
+ *
+ * \return 0 on success; -1 on error.
  */
-void readFromSSDPSocket(
+int readFromSSDPSocket(
 	/* [in] SSDP socket. */
 	SOCKET socket);
 

--- a/upnp/src/ssdp/ssdp_server.c
+++ b/upnp/src/ssdp/ssdp_server.c
@@ -805,7 +805,7 @@ static void ssdp_event_handler_thread(
 	free_ssdp_event_handler_data(data);
 }
 
-void readFromSSDPSocket(SOCKET socket)
+int readFromSSDPSocket(SOCKET socket)
 {
 	char *requestBuf = NULL;
 	char staticBuf[BUFSIZE];
@@ -896,8 +896,11 @@ void readFromSSDPSocket(SOCKET socket)
 			if (ThreadPoolAdd(&gRecvThreadPool, &job, NULL) != 0)
 				free_ssdp_event_handler_data(data);
 		}
-	} else
+		return 0;
+	} else {
 		free_ssdp_event_handler_data(data);
+		return -1;
+    }
 }
 
 /*!


### PR DESCRIPTION
In case of a socket error, the socket was not removed from the select pool, causing future select() calls to return immediately, and readFromSSDPSocket() to be called just after on the failing socket. This was causing a high CPU load.