### PR TITLE
UpnpInet: remove iphlpapi include

### DIFF
--- a/upnp/inc/UpnpInet.h
+++ b/upnp/inc/UpnpInet.h
@@ -17,7 +17,6 @@
 #ifdef _WIN32
 	#include <stdarg.h>
 	#include <winsock2.h>
-	#include <iphlpapi.h>
 	#include <ws2tcpip.h>
 
 	#define UpnpCloseSocket closesocket

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -73,7 +73,7 @@
 #include "posix_overwrites.h"
 
 #ifdef _WIN32
-/* Do not include these files */
+	#include <iphlpapi.h>
 #else
 	#include <ifaddrs.h>
 	#include <sys/ioctl.h>


### PR DESCRIPTION
Not only is it unused, projects that pass -DNOCOMM under Windows end up failing compilation as more headers need to be included. Simpler to just not include.