### PR TITLE
disable fseeko usage on 32-bit Android older than API 24

### DIFF
--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -73,6 +73,9 @@
 	#include <sys/types.h>
 	#include <sys/utsname.h>
 	#include <sys/wait.h>
+	#if defined(__ANDROID__) && (!defined(__USE_FILE_OFFSET64) || __ANDROID_API__ < 24)
+		#define fseeko fseek
+	#endif
 #endif /* _WIN32 */
 
 /*


### PR DESCRIPTION
feesko is not supported on 32-bit Android older than API 24 [1]. Older SDKs would allow the call but the 64-bit off_t was not accurate. With the NDK26 the call is hidden in that case and calling fseeko() results in a compilation error.

[1] https://android.googlesource.com/platform/bionic/+/main/docs/32-bit-abi.md