### PR TITLE
Fix cmake redefinition warnings

### DIFF
--- a/upnp/inc/upnpconfig.h.cm
+++ b/upnp/inc/upnpconfig.h.cm
@@ -38,18 +38,22 @@
  ***************************************************************************/
 
 /** The library version (string) e.g. "1.3.0" */
+#undef UPNP_VERSION_STRING
 #cmakedefine UPNP_VERSION_STRING "${UPNP_VERSION_STRING}"
 
 /** Major version of the library */
+#undef UPNP_VERSION_MAJOR
 #cmakedefine UPNP_VERSION_MAJOR ${UPNP_VERSION_MAJOR}
 
 /** Minor version of the library */
+#undef UPNP_VERSION_MINOR
 #cmakedefine UPNP_VERSION_MINOR ${UPNP_VERSION_MINOR}
 #ifndef UPNP_VERSION_MINOR
 #	define UPNP_VERSION_MINOR 0
 #endif
 
 /** Patch version of the library */
+#undef UPNP_VERSION_PATCH
 #cmakedefine UPNP_VERSION_PATCH ${UPNP_VERSION_PATCH}
 #ifndef UPNP_VERSION_PATCH
 #	define UPNP_VERSION_PATCH 0


### PR DESCRIPTION
Fixes stuff like this:

```
[ 75%] Building C object upnp/CMakeFiles/upnp_static.dir/src/ssdp/ssdp_server.c.o

                 from /home/mroberto/programs/pupnp/maint/github-creator/upnp/src/inc/upnputil.h:40,
                 from /home/mroberto/programs/pupnp/maint/github-creator/upnp/src/inc/membuffer.h:40,
                 from /home/mroberto/programs/pupnp/maint/github-creator/upnp/src/inc/httpparser.h:41,
                 from /home/mroberto/programs/pupnp/maint/github-creator/upnp/src/inc/ssdplib.h:45,
                 from /home/mroberto/programs/pupnp/maint/github-creator/upnp/src/ssdp/ssdp_server.c:45:
/home/mroberto/programs/pupnp/maint/github-creator/upnp/inc/upnpconfig.h:42: warning: "UPNP_VERSION_STRING" redefined
   42 | #define UPNP_VERSION_STRING "1.14.20"
      | 
In file included from /home/mroberto/programs/pupnp/maint/github-creator/upnp/src/inc/config.h:36,
                 from /home/mroberto/programs/pupnp/maint/github-creator/upnp/src/ssdp/ssdp_server.c:41:
/home/mroberto/programs/pupnp/maint/github-creator/build/autoconfig.h:5: note: this is the location of the previous definition
    5 | #define UPNP_VERSION_STRING "17.1.11"
      | 
/home/mroberto/programs/pupnp/maint/github-creator/upnp/inc/upnpconfig.h:45: warning: "UPNP_VERSION_MAJOR" redefined
   45 | #define UPNP_VERSION_MAJOR 1
      | 
/home/mroberto/programs/pupnp/maint/github-creator/build/autoconfig.h:8: note: this is the location of the previous definition
    8 | #define UPNP_VERSION_MAJOR 17
      | 
/home/mroberto/programs/pupnp/maint/github-creator/upnp/inc/upnpconfig.h:48: warning: "UPNP_VERSION_MINOR" redefined
   48 | #define UPNP_VERSION_MINOR 14
      | 
/home/mroberto/programs/pupnp/maint/github-creator/build/autoconfig.h:11: note: this is the location of the previous definition
   11 | #define UPNP_VERSION_MINOR 1
      | 
/home/mroberto/programs/pupnp/maint/github-creator/upnp/inc/upnpconfig.h:51: warning: "UPNP_VERSION_PATCH" redefined
   51 | #define UPNP_VERSION_PATCH 20
      | 
/home/mroberto/programs/pupnp/maint/github-creator/build/autoconfig.h:18: note: this is the location of the previous definition
   18 | #define UPNP_VERSION_PATCH 11
      | 
```
