### PR TITLE
fix 32-bit format warnings

### DIFF
--- a/upnp/inc/UpnpGlobal.h
+++ b/upnp/inc/UpnpGlobal.h
@@ -44,12 +44,19 @@
 	 * PRIzx
 	 */
 	#ifdef UPNP_USE_MSVCPP
-		/* define some things the M$ VC++ doesn't know */
-		#define UPNP_INLINE _inline
+		#if _MSC_VER > 1900
+			#define UPNP_INLINE inline
+			#define PRIzd "zd"
+			#define PRIzu "zu"
+			#define PRIzx "zx"
+		#else
+			/* define some things the M$ VC++ doesn't know */
+			#define UPNP_INLINE _inline
 typedef __int64 int64_t;
-		#define PRIzd "ld"
-		#define PRIzu "lu"
-		#define PRIzx "lx"
+			#define PRIzd "ld"
+			#define PRIzu "lu"
+			#define PRIzx "lx"
+		#endif
 	#endif /* UPNP_USE_MSVCPP */
 
 	#ifdef UPNP_USE_BCBPP

--- a/upnp/src/gena/gena_device.c
+++ b/upnp/src/gena/gena_device.c
@@ -449,7 +449,7 @@ static char *AllocGenaHeaders(
 		"%s%s%" PRIzu "%s%s%s",
 		HEADER_LINE_1,
 		HEADER_LINE_2A,
-		(unsigned long)strlen(propertySet) + 2,
+		strlen(propertySet) + 2,
 		HEADER_LINE_2B,
 		HEADER_LINE_3,
 		HEADER_LINE_4);

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -630,7 +630,7 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 					rc = snprintf(Chunk_Header,
 						sizeof(Chunk_Header),
 						"%" PRIzx "\r\n",
-						(unsigned long)num_read);
+						num_read);
 					if (rc < 0 ||
 						(unsigned int)rc >=
 							sizeof(Chunk_Header)) {
@@ -1769,10 +1769,7 @@ int http_MakeMessage(membuffer *buf,
 		} else if (c == 'd') {
 			/* integer */
 			num = (size_t)va_arg(argp, int);
-			rc = snprintf(tempbuf,
-				sizeof(tempbuf),
-				"%" PRIzu,
-				(unsigned long)num);
+			rc = snprintf(tempbuf, sizeof(tempbuf), "%" PRIzu, num);
 			if (rc < 0 || (unsigned int)rc >= sizeof(tempbuf) ||
 				membuffer_append(buf, tempbuf, strlen(tempbuf)))
 				goto error_handler;


### PR DESCRIPTION
Seems this PRIzu takes size_t, not unsigned long.