### PR TITLE
Allow setting MaxJobsTotal for ThreadPools

### DIFF
--- a/upnp/inc/upnptools.h
+++ b/upnp/inc/upnptools.h
@@ -57,6 +57,13 @@ extern "C" {
 	#endif
 
 /*!
+ * \brief Sets the maximum number of jobs in the internal thread pool.
+ * This option is intended for server applications to avoid an overflow of
+ * jobs when serving e.g. many web requests.
+ */
+UPNP_EXPORT_SPEC void UpnpSetMaxJobsTotal(int mjt);
+
+/*!
  * \brief Converts an SDK error code into a string error message suitable for
  * display. The memory returned from this function should NOT be freed.
  *

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -364,7 +364,7 @@ static int UpnpInitThreadPools(void)
 	TPAttrSetStackSize(&attr, THREAD_STACK_SIZE);
 	TPAttrSetJobsPerThread(&attr, JOBS_PER_THREAD);
 	TPAttrSetIdleTime(&attr, THREAD_IDLE_TIME);
-	TPAttrSetMaxJobsTotal(&attr, MAX_JOBS_TOTAL);
+	TPAttrSetMaxJobsTotal(&attr, maxJobsTotal);
 
 	if (ThreadPoolInit(&gSendThreadPool, &attr) != UPNP_E_SUCCESS) {
 		ret = UPNP_E_INIT_FAILED;

--- a/upnp/src/api/upnptools.c
+++ b/upnp/src/api/upnptools.c
@@ -40,6 +40,8 @@
 	#include "upnp.h"
 	#include "upnptools.h"
 
+	#include "ThreadPool.h"
+
 	#include "uri.h"
 
 	#include <stdarg.h>
@@ -124,6 +126,8 @@ const char *UpnpGetErrorMessage(int rc)
 
 	return "Unknown error code";
 }
+
+void UpnpSetMaxJobsTotal(int mjt) { TPSetMaxJobsTotal(mjt); }
 
 /*!
  * \todo There is some unnecessary allocation and deallocation going on here

--- a/upnp/src/threadutil/ThreadPool.c
+++ b/upnp/src/threadutil/ThreadPool.c
@@ -1067,6 +1067,10 @@ int ThreadPoolShutdown(ThreadPool *tp)
 	return 0;
 }
 
+int maxJobsTotal = DEFAULT_MAX_JOBS_TOTAL;
+
+void TPSetMaxJobsTotal(int mjt) { maxJobsTotal = mjt; }
+
 int TPAttrInit(ThreadPoolAttr *attr)
 {
 	if (!attr)
@@ -1078,7 +1082,7 @@ int TPAttrInit(ThreadPoolAttr *attr)
 	attr->stackSize = DEFAULT_STACK_SIZE;
 	attr->schedPolicy = DEFAULT_POLICY;
 	attr->starvationTime = DEFAULT_STARVATION_TIME;
-	attr->maxJobsTotal = DEFAULT_MAX_JOBS_TOTAL;
+	attr->maxJobsTotal = maxJobsTotal;
 
 	return 0;
 }

--- a/upnp/src/threadutil/ThreadPool.h
+++ b/upnp/src/threadutil/ThreadPool.h
@@ -120,6 +120,7 @@ typedef enum priority
 
 /*! default max jobs used TPAttrInit */
 #define DEFAULT_MAX_JOBS_TOTAL 100
+extern int maxJobsTotal;
 
 /*!
  * \brief Statistics.
@@ -248,6 +249,13 @@ typedef struct THREADPOOL
 	/*! statistics */
 	ThreadPoolStats stats;
 } ThreadPool;
+
+/*!
+ * \brief Sets the maximum number of jobs in the thread pool.
+ * This option is intended for server applications to avoid an overflow of
+ * jobs when serving e.g. many web requests.
+ */
+void TPSetMaxJobsTotal(int mjt);
 
 /*!
  * \brief Initializes and starts ThreadPool. Must be called first and


### PR DESCRIPTION
avoids ThreadPoolAdd too many jobs: 100
in cases where heavy load is expected

Closes #449 