### PR TITLE
ixmlparser.c: Fixes heap-buffer-overflow

### DIFF
--- a/ixml/src/ixmlparser.c
+++ b/ixml/src/ixmlparser.c
@@ -972,6 +972,10 @@ static int Parser_getChar(
 		/* Read in escape characters of type &#xnn where nn is a
 		 * hexadecimal value */
 		pnum = src + strlen(ESC_HEX);
+		if (!*pnum) {
+			line = __LINE__;
+			goto fail_entity;
+		}
 		sum = 0;
 		while (strchr(HEX_NUMBERS, (int)*pnum) != 0) {
 			c = *pnum;

--- a/ixml/src/ixmlparser.c
+++ b/ixml/src/ixmlparser.c
@@ -995,6 +995,10 @@ static int Parser_getChar(
 		/* Read in escape characters of type &#nn where nn is a decimal
 		 * value */
 		pnum = src + strlen(ESC_DEC);
+		if (!*pnum) {
+			line = __LINE__;
+			goto fail_entity;
+		}
 		sum = 0;
 		while (strchr(DEC_NUMBERS, (int)*pnum) != 0) {
 			/* Keep away from INT_MAX to avoid overflow. Using 10 in


### PR DESCRIPTION
```
==1008254==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x507000000145 at pc 0x56086b6fe129 bp 0x7ffd0c0527d0 sp 0x7ffd0c0527c8 READ of size 1 at 0x507000000145 thread T0
    #0 0x56086b6fe128 in Parser_getChar /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixmlparser.c:999:35
    #1 0x56086b6fcdb6 in Parser_copyToken /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixmlparser.c:1163:7
    #2 0x56086b6f7537 in Parser_processContent /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixmlparser.c:1537:7
    #3 0x56086b6f2818 in Parser_getNextNode /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixmlparser.c:2067:9
    #4 0x56086b6efa7f in Parser_parseDocument /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixmlparser.c:2589:7
    #5 0x56086b6eea2e in Parser_LoadDocument /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixmlparser.c:2831:7
    #6 0x56086b6e9be0 in ixmlLoadDocumentEx /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixml.c:333:9
    #7 0x56086b6de05a in CheckXML /home/mroberto/programs/pupnp/maint/github-creator/fuzzer/FuzzIxml.c:18:7
    #8 0x56086b6de48e in LLVMFuzzerTestOneInput /home/mroberto/programs/pupnp/maint/github-creator/fuzzer/FuzzIxml.c:54:8
    #9 0x56086b5e0052 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /home/abuild/rpmbuild/BUILD/llvm-19.1.3.src/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:614:13
    #10 0x56086b5c7c45 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /home/abuild/rpmbuild/BUILD/llvm-19.1.3.src/projects/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:328:6
    #11 0x56086b5cdee8 in fuzzer::FuzzerDriver(int*, char***, int(*)(unsigned char const*, unsigned long)) /home/abuild/rpmbuild/BUILD/llvm-19.1.3.src/projects/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:863:9
    #12 0x56086b5fa4b3 in main /home/abuild/rpmbuild/BUILD/llvm-19.1.3.src/projects/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #13 0x7f930a62a2ad in __libc_start_call_main /usr/src/debug/glibc-2.40/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #14 0x7f930a62a378 in __libc_start_main@GLIBC_2.2.5 /usr/src/debug/glibc-2.40/csu/../csu/libc-start.c:360:3
    #15 0x56086b5c21a4 in _start /home/abuild/rpmbuild/BUILD/glibc-2.40/csu/../sysdeps/x86_64/start.S:115

0x507000000145 is located 0 bytes after 69-byte region [0x507000000100,0x507000000145) allocated by thread T0 here:
    #0 0x56086b69c637 in malloc /home/abuild/rpmbuild/BUILD/llvm-19.1.3.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x56086b6eed0f in Parser_readFileOrBuffer /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixmlparser.c:2778:13
    #2 0x56086b6ee8d7 in Parser_LoadDocument /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixmlparser.c:2824:7
    #3 0x56086b6e9be0 in ixmlLoadDocumentEx /home/mroberto/programs/pupnp/maint/github-creator/ixml/src/ixml.c:333:9
    #4 0x56086b6de05a in CheckXML /home/mroberto/programs/pupnp/maint/github-creator/fuzzer/FuzzIxml.c:18:7
    #5 0x56086b6de48e in LLVMFuzzerTestOneInput /home/mroberto/programs/pupnp/maint/github-creator/fuzzer/FuzzIxml.c:54:8
    #6 0x56086b5e0052 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /home/abuild/rpmbuild/BUILD/llvm-19.1.3.src/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:614:13
    #7 0x56086b5c7c45 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /home/abuild/rpmbuild/BUILD/llvm-19.1.3.src/projects/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:328:6
    #8 0x56086b5cdee8 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /home/abuild/rpmbuild/BUILD/llvm-19.1.3.src/projects/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:863:9
    #9 0x56086b5fa4b3 in main /home/abuild/rpmbuild/BUILD/llvm-19.1.3.src/projects/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #10 0x7f930a62a2ad in __libc_start_call_main /usr/src/debug/glibc-2.40/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
```
