### PR TITLE
Fix subscription requests not working on Windows due to a missing netmask

### DIFF
--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -3663,8 +3663,10 @@ int UpnpGetIfInfo(const char *IfName)
 	PIP_ADAPTER_UNICAST_ADDRESS uni_addr;
 	SOCKADDR *ip_addr;
 	struct in_addr v4_addr;
+	struct in_addr v4_netmask;
 	struct in6_addr v6_addr;
 	ULONG adapts_sz = 0;
+	ULONG mask = 0;
 	ULONG ret;
 	int ifname_found = 0;
 	int valid_addr_found = 0;
@@ -3775,7 +3777,8 @@ int UpnpGetIfInfo(const char *IfName)
 					&((struct sockaddr_in *)ip_addr)
 						 ->sin_addr,
 					sizeof(v4_addr));
-				/* TODO: Retrieve IPv4 netmask */
+				mask = htonl(ULONG_MAX << (32 - uni_addr->OnLinkPrefixLength));
+				memcpy(&v4_netmask, &mask, sizeof(v4_netmask));
 				valid_addr_found = 1;
 				break;
 			case AF_INET6:
@@ -3824,6 +3827,7 @@ int UpnpGetIfInfo(const char *IfName)
 		return UPNP_E_INVALID_INTERFACE;
 	}
 	inet_ntop(AF_INET, &v4_addr, gIF_IPV4, sizeof(gIF_IPV4));
+	inet_ntop(AF_INET, &v4_netmask, gIF_IPV4_NETMASK, sizeof(gIF_IPV4_NETMASK));
 	inet_ntop(AF_INET6, &v6_addr, gIF_IPV6, sizeof(gIF_IPV6));
 #else
 	struct ifaddrs *ifap, *ifa;


### PR DESCRIPTION
Subscription packets are not properly handled on Windows due to a missing IPv4 netmask.

The following call would return 0 because the `gIF_IPV4_NETMASK` was not filled on Windows:
https://github.com/pupnp/pupnp/blob/48e7adc38b1fa071090b74723174c6a4c776fba4/upnp/src/gena/gena_device.c#L1252

Causing `gena_process_subscription_request` to return a `HTTP_PRECONDITION_FAILED` (412) to the user/subscriber:
https://github.com/pupnp/pupnp/blob/48e7adc38b1fa071090b74723174c6a4c776fba4/upnp/src/gena/gena_device.c#L1464

This fix creates the netmask using the `OnLinkPrefixLength` stored in the `uni_addr`.

Most likely related issues:

https://github.com/pupnp/pupnp/issues/379
https://github.com/pupnp/pupnp/pull/181