### PR TITLE
Improve SSDP initialization and error handling

### DIFF
--- a/upnp/src/ssdp/ssdp_device.c
+++ b/upnp/src/ssdp/ssdp_device.c
@@ -254,10 +254,17 @@ static int NewRequestHandler(
 		return UPNP_E_INVALID_PARAM;
 	}
 
+	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = DestAddr->sa_family;
 	hints.ai_socktype = SOCK_DGRAM;
 	hints.ai_flags = AI_PASSIVE;
-	getaddrinfo(NULL, SSDP_PORT_STR, &hints, &res);
+	if ((rc = getaddrinfo(NULL, SSDP_PORT_STR, &hints, &res)) != 0) {
+		UpnpPrintf(UPNP_INFO, SSDP, __FILE__, __LINE__,
+			"SSDP_LIB: New Request Handler:"
+			"Error in getaddrinfo(): %s\n", gai_strerror(rc));
+		ret = UPNP_E_SOCKET_ERROR;
+		goto end_NewRequestHandler;
+	}
 	ReplySock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 	if (ReplySock == INVALID_SOCKET) {
 		ProcessSocketError(__FILE__, __LINE__, "socket");


### PR DESCRIPTION
It was possible for some uninitialized garbage to cause getaddrinfo() to fail on glibc 2.41, which would crash the client program.  Instead, zero the whole struct, and gracefully handle getaddrinfo() failures.