### PR TITLE
readFromSSDPSocket: Don't return error when sockets receive zero length packet

### DIFF
--- a/upnp/src/ssdp/ssdp_server.c
+++ b/upnp/src/ssdp/ssdp_server.c
@@ -897,10 +897,10 @@ int readFromSSDPSocket(SOCKET socket)
 				free_ssdp_event_handler_data(data);
 		}
 		return 0;
-	} else if (byteReceived < 0) {
-		free_ssdp_event_handler_data(data);
-		return -1;
 	}
+
+	free_ssdp_event_handler_data(data);
+	return (byteReceived < 0) ? -1 : 0;
 }
 
 /*!


### PR DESCRIPTION
Update readFromSSDPSocket to not return an error when a zero length packet is received.

Apparently it's possible/valid to receive a zero length packet on an UDP socket.
https://stackoverflow.com/questions/12505892/under-linux-can-recv-ever-return-0-on-udp

And apparently some iPhones like to send zero length packets.

Close #498.