### PR TITLE
Don't assume strndup to be missing on Windows

### DIFF
--- a/upnp/src/api/UpnpString.c
+++ b/upnp/src/api/UpnpString.c
@@ -42,7 +42,7 @@ static size_t strnlen(const char *s, size_t n)
 #endif		       /* _WIN32 */
 
 /* strndup() is a GNU extension. */
-#if !HAVE_STRNDUP || defined(_WIN32)
+#if !HAVE_STRNDUP
 static char *strndup(const char *__string, size_t __n)
 {
 	size_t strsize = strnlen(__string, __n);
@@ -55,7 +55,7 @@ static char *strndup(const char *__string, size_t __n)
 
 	return newstr;
 }
-#endif /* HAVE_STRNDUP && !defined(_WIN32) */
+#endif /* !HAVE_STRNDUP */
 
 /*!
  * \brief Internal implementation of the class UpnpString.


### PR DESCRIPTION
Recent (git) versions of mingw-w64 have started providing the strndup function (because it is part of C23).

The configure check for HAVE_STRNDUP does detect this correctly, thus just rely on that check instead of hardcoding extra conditions on top of it.

This fixes building with such versions of mingw-w64.