### PR TITLE
fix: replace atoi() with strtol() in parse_uri() — CVE-2026-41682 (CWE-195)

### DIFF
--- a/upnp/src/genlib/net/uri/uri.c
+++ b/upnp/src/genlib/net/uri/uri.c
@@ -403,10 +403,13 @@ static int parse_hostport(
 		srvport = c;
 		while (*c != '\0' && isdigit(*c))
 			c++;
-		port = (unsigned short int)atoi(srvport);
-		if (port == 0)
-			/* Bad port number. */
-			return UPNP_E_INVALID_URL;
+		{
+			long port_l = strtol(srvport, NULL, 10);
+			if (port_l <= 0 || port_l > 65535)
+				/* Bad port number. */
+				return UPNP_E_INVALID_URL;
+			port = (unsigned short int)port_l;
+		}
 	} else
 		/* Port was not specified, use default port. */
 		port = defaultPort;


### PR DESCRIPTION
## Summary

Fixes the port truncation vulnerability in `parse_uri()` reported as CVE-2026-41682 / GHSA-q522-6w45-4j58.

### Root cause

`atoi()` returns a plain `int`. The subsequent `(unsigned short int)` cast silently truncates out-of-range values, and the `port == 0` guard only catches the single truncation case that lands exactly on zero:

| Input | `atoi()` | `(uint16_t)` | Caught? |
|-------|----------|--------------|---------|
| `"65537"` | 65537 | 1 | **NO** |
| `"131073"` | 131073 | 1 | **NO** |
| `"-1"` | -1 | 65535 | **NO** |
| `"65536"` | 65536 | 0 | yes |

A rogue UPnP device (SSDP spoofing or MITM) returning an out-of-range port in a device description or `LOCATION` header can redirect a control point to an arbitrary internal port, enabling SSRF port confusion and port-based ACL bypass.

### Fix

Replace `atoi()` with `strtol()` and validate the full `[1, 65535]` range before the cast:

```c
/* Before */
port = (unsigned short int)atoi(srvport);
if (port == 0)
    return UPNP_E_INVALID_URL;

/* After */
long port_l = strtol(srvport, NULL, 10);
if (port_l <= 0 || port_l > 65535)
    return UPNP_E_INVALID_URL;
port = (unsigned short int)port_l;
```

Found by COBALT static analyzer + Z3 SMT formal verification (Dominik Blain, QreativeLab).  
Disclosure timeline and Z3 proof in GHSA-q522-6w45-4j58.