### PR TITLE
High memory usage after #504

### DIFF
--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -533,6 +533,7 @@ error_handler:
 		}
 		handle_error(&info, http_error_code, major, minor);
 	}
+	remove_active_connection(info.socket);
 	sock_destroy(&info, SD_BOTH);
 	httpmsg_destroy(h_msg);
 	free(request);


### PR DESCRIPTION
#504 added a feature to store sockets in a list to improve shutdown performance. Memory is allocated for every connection, but as far as I can tell it is only freed on shutdown. This results in memory usage slowly increasing over time.

I was able to reproduce this with the tv_device sample.

I've added the appropriate free call after a request has been handled, but I'm not familiar enough with the library architecture to know if this is the most idiomatic fix.

Below are some valgrind massif heap profiler screenshots.

Before
<img width="2560" height="1392" alt="Screenshot 2026-05-20 162134" src="https://github.com/user-attachments/assets/06b8307c-a534-4b9f-a362-bc7ad19f7137" />

After
<img width="2560" height="1392" alt="Screenshot 2026-05-20 162149" src="https://github.com/user-attachments/assets/98a54c59-3035-48e8-84ff-710d8f5000db" />