### PR TITLE
ThreadPool: backtrace on first overflow + raise DEFAULT_MAX_JOBS_TOTAL (issue #178)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,13 @@ endif()
 check_function_exists(strnlen HAVE_STRNLEN)
 check_function_exists(strndup HAVE_STRNDUP)
 
+if(UPNP_ENABLE_BACKTRACE AND NOT WIN32)
+	check_include_file(execinfo.h HAVE_EXECINFO_H)
+	if(HAVE_EXECINFO_H)
+		check_function_exists(backtrace HAVE_BACKTRACE)
+	endif()
+endif()
+
 include(CheckCCompilerFlag)
 check_c_compiler_flag(-fmacro-prefix-map=from=to HAVE_MACRO_PREFIX_MAP)
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,12 @@
 Version 1.18.6
 *******************************************************************************
 
+- Issue #178: ThreadPool: print backtrace on first "too many jobs" via new
+  UPNP_ENABLE_BACKTRACE CMake option / --enable-backtrace configure switch
+  (enabled by default; requires execinfo.h).
+- Issue #178: raise DEFAULT_MAX_JOBS_TOTAL from 100 to 1000 to better handle
+  networks with many UPnP devices.
+
 
 
 *******************************************************************************

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -25,6 +25,7 @@ UPNP_deprecated_option (ssdp UPNP_ENABLE_SSDP "SSDP part" ON)
 UPNP_deprecated_option (unspecified_server UPNP_ENABLE_UNSPECIFIED_SERVER "unspecified SERVER header" OFF)
 UPNP_deprecated_option (webserver UPNP_ENABLE_WEBSERVER "integrated web server" ${UPNP_ENABLE_DEVICE_API})
 UPNP_deprecated_option (reuseaddr UPNP_MINISERVER_REUSEADDR "Bind the miniserver socket with SO_REUSEADDR to allow clean restarts" ON)
+option (UPNP_ENABLE_BACKTRACE "Print backtrace on first thread pool overflow" ON)
 
 if (UPNP_ENABLE_WEBSERVER AND NOT UPNP_ENABLE_DEVICE_API)
 	message (FATAL_ERROR "The webserver does not work without the device-api code")

--- a/configure.ac
+++ b/configure.ac
@@ -778,6 +778,12 @@ AC_CHECK_FUNC(strnlen,
 	AC_DEFINE(HAVE_STRNLEN, 1, [Defines if strnlen is available on your system]))
 AC_CHECK_FUNC(strndup,
 	AC_DEFINE(HAVE_STRNDUP, 1, [Defines if strndup is available on your system]))
+RT_BOOL_ARG_ENABLE([backtrace], [yes], [backtrace on thread pool overflow])
+if test "x$enable_backtrace" = xyes ; then
+	AC_CHECK_HEADERS([execinfo.h],
+		[AC_CHECK_FUNC(backtrace,
+			[AC_DEFINE(HAVE_BACKTRACE, 1, [Define if backtrace() is available])])])
+fi
 #
 # Solaris needs -lsocket -lnsl -lrt
 AC_SEARCH_LIBS([bind],           [socket])

--- a/upnp/src/threadutil/ThreadPool.c
+++ b/upnp/src/threadutil/ThreadPool.c
@@ -39,6 +39,7 @@
 #endif
 
 #include "ThreadPool.h"
+#include "config.h"
 
 #include "FreeList.h"
 
@@ -46,6 +47,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h> /* for memset()*/
+
+#ifdef HAVE_BACKTRACE
+	#include <execinfo.h>
+	#include <unistd.h>
+#endif
 
 /*!
  * \brief Returns the difference in milliseconds between two timeval structures.
@@ -839,11 +845,19 @@ int ThreadPoolAdd(ThreadPool *tp, ThreadPoolJob *job, int *jobId)
 
 	totalJobs = tp->highJobQ.size + tp->lowJobQ.size + tp->medJobQ.size;
 	if (totalJobs >= tp->attr.maxJobsTotal) {
-		if (tp->stats.droppedJobs == 0)
+		if (tp->stats.droppedJobs == 0) {
 			fprintf(stderr,
 				"libupnp ThreadPoolAdd too many jobs: %ld"
 				" (dropping; further messages suppressed)\n",
 				totalJobs);
+#ifdef HAVE_BACKTRACE
+			{
+				void *frames[20];
+				int n = backtrace(frames, 20);
+				backtrace_symbols_fd(frames, n, STDERR_FILENO);
+			}
+#endif
+		}
 		tp->stats.droppedJobs++;
 		goto exit_function;
 	}

--- a/upnp/src/threadutil/ThreadPool.h
+++ b/upnp/src/threadutil/ThreadPool.h
@@ -119,7 +119,7 @@ typedef enum priority
 #define DEFAULT_FREE_ROUTINE NULL
 
 /*! default max jobs used TPAttrInit */
-#define DEFAULT_MAX_JOBS_TOTAL 100
+#define DEFAULT_MAX_JOBS_TOTAL 1000
 extern int maxJobsTotal;
 
 /*!

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -2,6 +2,59 @@ UPNP_Add_Unit_Test(test-upnp-list test_list.c)
 UPNP_Add_Unit_Test(test-upnp-init test_init.c)
 UPNP_Add_Unit_Test(test-upnp-log test_log.c)
 UPNP_Add_Unit_Test(test-upnp-url test_url.c)
+# test_threadpool_overflow calls internal ThreadPool API (ThreadPoolInit,
+# TPAttrInit, …) that have hidden visibility in the shared library.  Compile
+# the three ThreadPool translation units directly into each test variant so
+# both shared and static builds test the same code without needing symbol
+# exports.
+set(TP_OVERFLOW_SOURCES
+	test_threadpool_overflow.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../src/threadutil/ThreadPool.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../src/threadutil/FreeList.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../src/threadutil/LinkedList.c
+)
+set(TP_OVERFLOW_INCLUDES
+	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/threadutil
+	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/inc
+	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../inc
+	PRIVATE ${PUPNP_BINARY_DIR}
+)
+
+if(UPNP_BUILD_SHARED)
+	add_executable(test-upnp-threadpool-overflow ${TP_OVERFLOW_SOURCES})
+	target_include_directories(test-upnp-threadpool-overflow
+		${TP_OVERFLOW_INCLUDES})
+	target_compile_definitions(test-upnp-threadpool-overflow
+		PRIVATE $<$<BOOL:${MSVC}>:UPNP_USE_MSVCPP>)
+	target_link_libraries(test-upnp-threadpool-overflow PRIVATE Threads::Shared)
+	if(HAVE_MACRO_PREFIX_MAP)
+		target_compile_options(test-upnp-threadpool-overflow
+			PRIVATE -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=.)
+	endif()
+	add_test(NAME test-upnp-threadpool-overflow
+		COMMAND test-upnp-threadpool-overflow)
+	if(MSVC OR MSYS OR MINGW OR CYGWIN)
+		UPNP_Find_Test_Env(test-upnp-threadpool-overflow TEST_ENV)
+		set_tests_properties(test-upnp-threadpool-overflow
+			PROPERTIES ENVIRONMENT "${TEST_ENV}")
+	endif()
+endif()
+
+if(UPNP_BUILD_STATIC)
+	add_executable(test-upnp-threadpool-overflow-static ${TP_OVERFLOW_SOURCES})
+	target_include_directories(test-upnp-threadpool-overflow-static
+		${TP_OVERFLOW_INCLUDES})
+	target_compile_definitions(test-upnp-threadpool-overflow-static
+		PRIVATE $<$<BOOL:${MSVC}>:UPNP_USE_MSVCPP>)
+	target_link_libraries(test-upnp-threadpool-overflow-static
+		PRIVATE Threads::Static)
+	if(HAVE_MACRO_PREFIX_MAP)
+		target_compile_options(test-upnp-threadpool-overflow-static
+			PRIVATE -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=.)
+	endif()
+	add_test(NAME test-upnp-threadpool-overflow-static
+		COMMAND test-upnp-threadpool-overflow-static)
+endif()
 UPNP_Add_Unit_Test(test-upnp-gena-subscribe-dos test_gena_subscribe_dos.c)
 UPNP_Add_Unit_Test(test-upnp-gena-subscribe-pressure test_gena_subscribe_pressure.c)
 # Both GENA issue-#435 tests read constants from config.h (a private header).

--- a/upnp/test/test_threadpool_overflow.c
+++ b/upnp/test/test_threadpool_overflow.c
@@ -1,0 +1,178 @@
+/* test_threadpool_overflow.c
+ *
+ * Regression test for issue #178: thread pool overflow detection and
+ * backtrace diagnostic.
+ *
+ * Uses ThreadPool directly (no full UPnP stack) with maxThreads=0 so
+ * the queue fills deterministically with no worker-thread races.
+ *
+ * Test A: jobs beyond maxJobsTotal are dropped and the droppedJobs counter
+ *         is incremented.
+ *
+ * Test B (POSIX + HAVE_BACKTRACE only): on the first overflow, stderr
+ *         contains the "too many jobs" message followed by at least one
+ *         backtrace frame line.
+ */
+
+#include "ThreadPool.h"
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef HAVE_BACKTRACE
+	#include <unistd.h>
+#endif
+
+/* Small limit so the test runs fast. */
+#define MAX_JOBS 5
+
+static void noop_job(void *arg) { (void)arg; }
+
+/* Test A: overflow detection and droppedJobs counter. */
+static int test_overflow_detection(void)
+{
+	ThreadPool tp;
+	ThreadPoolAttr attr;
+	ThreadPoolJob job;
+	int i, rc;
+
+	TPAttrInit(&attr);
+	TPAttrSetMaxJobsTotal(&attr, MAX_JOBS);
+	TPAttrSetMinThreads(&attr, 0);
+	TPAttrSetMaxThreads(&attr, 0);
+
+	if (ThreadPoolInit(&tp, &attr) != 0) {
+		fprintf(stderr, "test A: ThreadPoolInit failed\n");
+		return -1;
+	}
+
+	/* Fill the queue exactly to maxJobsTotal — all must succeed. */
+	for (i = 0; i < MAX_JOBS; i++) {
+		TPJobInit(&job, (start_routine)noop_job, NULL);
+		rc = ThreadPoolAdd(&tp, &job, NULL);
+		if (rc != 0) {
+			fprintf(stderr,
+				"test A: job %d rejected unexpectedly "
+				"(rc=%d)\n",
+				i,
+				rc);
+			ThreadPoolShutdown(&tp);
+			return -1;
+		}
+	}
+
+	/* One more must be dropped. */
+	TPJobInit(&job, (start_routine)noop_job, NULL);
+	rc = ThreadPoolAdd(&tp, &job, NULL);
+	if (rc == 0) {
+		fprintf(stderr,
+			"test A: job %d accepted but overflow was expected\n",
+			MAX_JOBS);
+		ThreadPoolShutdown(&tp);
+		return -1;
+	}
+
+	if (tp.stats.droppedJobs != 1) {
+		fprintf(stderr,
+			"test A: expected droppedJobs=1, got %ld\n",
+			tp.stats.droppedJobs);
+		ThreadPoolShutdown(&tp);
+		return -1;
+	}
+
+	ThreadPoolShutdown(&tp);
+	printf("test A PASS: overflow detected, droppedJobs=1\n");
+	return 0;
+}
+
+#ifdef HAVE_BACKTRACE
+/* Test B: backtrace lines appear on stderr on the first overflow. */
+static int test_backtrace_output(void)
+{
+	ThreadPool tp;
+	ThreadPoolAttr attr;
+	ThreadPoolJob job;
+	int i, pipefd[2], saved_fd;
+	char buf[4096];
+	ssize_t n;
+	int linecount;
+
+	TPAttrInit(&attr);
+	TPAttrSetMaxJobsTotal(&attr, MAX_JOBS);
+	TPAttrSetMinThreads(&attr, 0);
+	TPAttrSetMaxThreads(&attr, 0);
+
+	if (ThreadPoolInit(&tp, &attr) != 0) {
+		fprintf(stderr, "test B: ThreadPoolInit failed\n");
+		return -1;
+	}
+
+	/* Fill queue to maxJobsTotal. */
+	for (i = 0; i < MAX_JOBS; i++) {
+		TPJobInit(&job, (start_routine)noop_job, NULL);
+		ThreadPoolAdd(&tp, &job, NULL);
+	}
+
+	/* Redirect stderr to a pipe before triggering the first overflow. */
+	if (pipe(pipefd) != 0) {
+		fprintf(stderr, "test B: pipe() failed\n");
+		ThreadPoolShutdown(&tp);
+		return -1;
+	}
+	fflush(stderr);
+	saved_fd = dup(STDERR_FILENO);
+	dup2(pipefd[1], STDERR_FILENO);
+	close(pipefd[1]);
+
+	/* Trigger the overflow: prints "too many jobs" message + backtrace. */
+	TPJobInit(&job, (start_routine)noop_job, NULL);
+	ThreadPoolAdd(&tp, &job, NULL);
+
+	/* Restore stderr and collect what was written. */
+	fflush(stderr);
+	dup2(saved_fd, STDERR_FILENO);
+	close(saved_fd);
+	n = read(pipefd[0], buf, sizeof(buf) - 1);
+	buf[n > 0 ? (size_t)n : 0] = '\0';
+	close(pipefd[0]);
+
+	ThreadPoolShutdown(&tp);
+
+	/* Count newline-terminated lines. */
+	linecount = 0;
+	for (i = 0; buf[i]; i++)
+		if (buf[i] == '\n')
+			linecount++;
+
+	/*
+	 * Expect at least 2 lines: the "too many jobs" message and at least
+	 * one backtrace frame from backtrace_symbols_fd().
+	 */
+	if (linecount < 2) {
+		fprintf(stderr,
+			"test B: expected >=2 lines on first overflow"
+			" (got %d):\n%s\n",
+			linecount,
+			buf);
+		return -1;
+	}
+
+	printf("test B PASS: backtrace produced %d lines\n", linecount);
+	return 0;
+}
+#endif /* HAVE_BACKTRACE */
+
+int main(void)
+{
+	if (test_overflow_detection() != 0)
+		return EXIT_FAILURE;
+
+#ifdef HAVE_BACKTRACE
+	if (test_backtrace_output() != 0)
+		return EXIT_FAILURE;
+#endif
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Fixes #178.

Three things were already done on `main` before this PR:
- PR #179 (merged) fixed the "too many jobs" message format: added the
  `libupnp ThreadPoolAdd` prefix and the missing newline that caused log
  mangling.
- A subsequent commit suppressed repeated log spam: the message is printed
  only on the *first* drop; when the queue recovers a single "queue available
  again, N job(s) dropped" line is emitted.

This PR addresses the remaining two concerns from the issue:

### 1. Print a backtrace on the first overflow

A new `UPNP_ENABLE_BACKTRACE` CMake option (default **ON**) and a matching
`--enable-backtrace` autoconf switch detect `execinfo.h` / `backtrace()` at
configure time (available on Linux and macOS; silently disabled on Windows and
platforms without `execinfo.h`).

When the thread-pool queue first hits `maxJobsTotal`, `backtrace_symbols_fd()`
is called immediately after the "too many jobs" message so that the caller can
identify whether it is library code or application code filling the queue —
which was the reporter's specific ask.

### 2. Raise `DEFAULT_MAX_JOBS_TOTAL` from 100 to 1000

The old limit is easily exhausted on networks with many UPnP devices: an
M-SEARCH on a network with 50 devices, each advertising 3 services, generates
~150 SSDP response jobs in one burst.  1000 slots fit comfortably in memory
(job descriptors are small) and give ample headroom for typical deployments.
`UpnpSetMaxJobsTotal()` remains available for applications that need a
different ceiling.

### 3. Regression test

`test_threadpool_overflow.c` covers both concerns:

- **Test A** (all platforms): fills the queue to `maxJobsTotal` with a
  zero-thread pool (no races), then verifies the next `ThreadPoolAdd` fails
  and `tp.stats.droppedJobs == 1`.
- **Test B** (`HAVE_BACKTRACE` platforms): redirects stderr to a pipe,
  triggers the first overflow, and asserts that the output contains at least
  two lines (the "too many jobs" message + at least one backtrace frame).

Both shared and static variants are built; the ThreadPool translation units
are compiled directly into the test binary to avoid hidden-visibility linker
errors.

## Test plan

- [ ] CI passes on Linux, macOS, Windows, OmniOS
- [ ] `test-upnp-threadpool-overflow` and `test-upnp-threadpool-overflow-static` pass locally
- [ ] On Linux/macOS: backtrace lines appear in test output
- [ ] On Windows: test A still runs; test B is a no-op (no `execinfo.h`)