### PR TITLE
fix: use poll() on non-Windows, keep select() on Windows (fixes #519 hang)

### DIFF
--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -63,6 +63,7 @@
 	#ifndef _WIN32
 		#include <netinet/tcp.h> /* TCP_NODELAY */
 	#endif
+	#include <poll.h>
 	#include <stdio.h>
 	#include <stdlib.h>
 	#include <string.h>
@@ -660,14 +661,19 @@ void shutdown_all_active_connections(void)
 	/*--------------------------------------------------------------------*/
 }
 
-static UPNP_INLINE void fdset_if_valid(SOCKET sock, fd_set *set)
+static UPNP_INLINE void pollfd_if_valid(
+	SOCKET sock, struct pollfd *pfd, short events)
 {
 	if (sock != INVALID_SOCKET) {
-		FD_SET(sock, set);
+		pfd->fd = sock;
+		pfd->events = events;
+		pfd->revents = 0;
+	} else {
+		pfd->fd = -1;
 	}
 }
 
-static void web_server_accept(SOCKET listen_sock, fd_set *set)
+static void web_server_accept(SOCKET listen_sock, struct pollfd *pfd)
 {
 	/*--------------------------------------------------------------------*/
 	#ifdef INTERNAL_WEB_SERVER
@@ -676,11 +682,12 @@ static void web_server_accept(SOCKET listen_sock, fd_set *set)
 	struct sockaddr_storage clientAddr;
 	char errorBuffer[ERROR_BUFFER_LEN];
 
-	if (listen_sock != INVALID_SOCKET && FD_ISSET(listen_sock, set)) {
+	if (listen_sock != INVALID_SOCKET && (pfd->revents & POLLIN)) {
+
 		clientLen = sizeof(clientAddr);
-		asock = accept(listen_sock,
-			(struct sockaddr *)&clientAddr,
-			&clientLen);
+		asock = accept(
+			listen_sock, (struct sockaddr *)&clientAddr, &clientLen);
+
 		if (asock == INVALID_SOCKET) {
 			strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
 			UpnpPrintf(UPNP_INFO,
@@ -704,9 +711,10 @@ static void web_server_accept(SOCKET listen_sock, fd_set *set)
 	/*--------------------------------------------------------------------*/
 }
 
-static void ssdp_read(SOCKET *read_sock, fd_set *set)
+static void ssdp_read(SOCKET *read_sock, struct pollfd *pfd)
 {
-	if (*read_sock != INVALID_SOCKET && FD_ISSET(*read_sock, set)) {
+	if (*read_sock != INVALID_SOCKET && (pfd->revents & POLLIN)) {
+
 		int ret = readFromSSDPSocket(*read_sock);
 		if (ret != 0) {
 			UpnpPrintf(UPNP_INFO,
@@ -722,7 +730,7 @@ static void ssdp_read(SOCKET *read_sock, fd_set *set)
 	}
 }
 
-static int receive_from_stopSock(SOCKET ssock, fd_set *set)
+static int receive_from_stopSock(SOCKET ssock, struct pollfd *pfd)
 {
 	ssize_t byteReceived;
 	socklen_t clientLen;
@@ -730,21 +738,27 @@ static int receive_from_stopSock(SOCKET ssock, fd_set *set)
 	char requestBuf[256];
 	char buf_ntop[INET6_ADDRSTRLEN];
 
-	if (FD_ISSET(ssock, set)) {
+	if (ssock != INVALID_SOCKET && (pfd->revents & POLLIN)) {
+
 		clientLen = sizeof(clientAddr);
-		memset((char *)&clientAddr, 0, sizeof(clientAddr));
+		memset(&clientAddr, 0, sizeof(clientAddr));
+
 		byteReceived = recvfrom(ssock,
 			requestBuf,
 			(size_t)25,
 			0,
 			(struct sockaddr *)&clientAddr,
 			&clientLen);
+
 		if (byteReceived > 0) {
 			requestBuf[byteReceived] = '\0';
+
+			/* Convert IPv4 address to string */
 			inet_ntop(AF_INET,
 				&((struct sockaddr_in *)&clientAddr)->sin_addr,
 				buf_ntop,
 				sizeof(buf_ntop));
+
 			UpnpPrintf(UPNP_INFO,
 				MSERV,
 				__FILE__,
@@ -752,15 +766,18 @@ static int receive_from_stopSock(SOCKET ssock, fd_set *set)
 				"Received response: %s From host %s \n",
 				requestBuf,
 				buf_ntop);
+
 			UpnpPrintf(UPNP_PACKET,
 				MSERV,
 				__FILE__,
 				__LINE__,
 				"Received multicast packet: \n %s\n",
 				requestBuf);
-			if (NULL != strstr(requestBuf, "ShutDown")) {
+
+			if (strstr(requestBuf, "ShutDown") != NULL) {
 				return 1;
 			}
+
 		} else {
 			UpnpPrintf(UPNP_INFO,
 				MSERV,
@@ -774,6 +791,7 @@ static int receive_from_stopSock(SOCKET ssock, fd_set *set)
 	return 0;
 }
 
+	#define MINI_SERVER_MAX_PFDS 9
 /*!
  * \brief Run the miniserver.
  *
@@ -786,72 +804,77 @@ static void RunMiniServer(
 	MiniServerSockArray *mini_sock)
 {
 	char errorBuffer[ERROR_BUFFER_LEN];
-	fd_set expSet;
-	fd_set rdSet;
-	SOCKET maxMiniSock;
 	int ret = 0;
 	int stopSock = 0;
 
-	maxMiniSock = 0;
-	maxMiniSock = max(maxMiniSock, mini_sock->miniServerSock4);
-	maxMiniSock = max(maxMiniSock, mini_sock->miniServerSock6);
-	maxMiniSock = max(maxMiniSock, mini_sock->miniServerSock6UlaGua);
-	maxMiniSock = max(maxMiniSock, mini_sock->miniServerStopSock);
-	maxMiniSock = max(maxMiniSock, mini_sock->ssdpSock4);
-	maxMiniSock = max(maxMiniSock, mini_sock->ssdpSock6);
-	maxMiniSock = max(maxMiniSock, mini_sock->ssdpSock6UlaGua);
-	#ifdef INCLUDE_CLIENT_APIS
-	maxMiniSock = max(maxMiniSock, mini_sock->ssdpReqSock4);
-	maxMiniSock = max(maxMiniSock, mini_sock->ssdpReqSock6);
-	#endif /* INCLUDE_CLIENT_APIS */
-	++maxMiniSock;
+	struct pollfd fds[MINI_SERVER_MAX_PFDS];
+	int nfds = 0;
 
 	gMServState = MSERV_RUNNING;
+
 	while (!stopSock) {
-		FD_ZERO(&rdSet);
-		FD_ZERO(&expSet);
-		/* FD_SET()'s */
-		FD_SET(mini_sock->miniServerStopSock, &expSet);
-		FD_SET(mini_sock->miniServerStopSock, &rdSet);
-		fdset_if_valid(mini_sock->miniServerSock4, &rdSet);
-		fdset_if_valid(mini_sock->miniServerSock6, &rdSet);
-		fdset_if_valid(mini_sock->miniServerSock6UlaGua, &rdSet);
-		fdset_if_valid(mini_sock->ssdpSock4, &rdSet);
-		fdset_if_valid(mini_sock->ssdpSock6, &rdSet);
-		fdset_if_valid(mini_sock->ssdpSock6UlaGua, &rdSet);
+		nfds = 0;
+
+		/* Stop socket: watch for read + error */
+		pollfd_if_valid(mini_sock->miniServerStopSock,
+			&fds[nfds++],
+			POLLIN | POLLERR | POLLHUP);
+
+		pollfd_if_valid(
+			mini_sock->miniServerSock4, &fds[nfds++], POLLIN);
+
+		pollfd_if_valid(
+			mini_sock->miniServerSock6, &fds[nfds++], POLLIN);
+
+		pollfd_if_valid(
+			mini_sock->miniServerSock6UlaGua, &fds[nfds++], POLLIN);
+
+		pollfd_if_valid(mini_sock->ssdpSock4, &fds[nfds++], POLLIN);
+
+		pollfd_if_valid(mini_sock->ssdpSock6, &fds[nfds++], POLLIN);
+
+		pollfd_if_valid(
+			mini_sock->ssdpSock6UlaGua, &fds[nfds++], POLLIN);
+
 	#ifdef INCLUDE_CLIENT_APIS
-		fdset_if_valid(mini_sock->ssdpReqSock4, &rdSet);
-		fdset_if_valid(mini_sock->ssdpReqSock6, &rdSet);
+		pollfd_if_valid(mini_sock->ssdpReqSock4, &fds[nfds++], POLLIN);
+
+		pollfd_if_valid(mini_sock->ssdpReqSock6, &fds[nfds++], POLLIN);
 	#endif /* INCLUDE_CLIENT_APIS */
-		/* select() */
-		ret = select((int)maxMiniSock, &rdSet, NULL, &expSet, NULL);
-		if (ret == SOCKET_ERROR && errno == EINTR) {
+
+		/* poll() */
+		ret = poll(fds, nfds, -1);
+
+		if (ret < 0 && errno == EINTR) {
 			continue;
 		}
-		if (ret == SOCKET_ERROR) {
+
+		if (ret < 0) {
 			strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
 			UpnpPrintf(UPNP_CRITICAL,
 				SSDP,
 				__FILE__,
 				__LINE__,
-				"Error in select(): %s\n",
+				"Error in poll(): %s\n",
 				errorBuffer);
 			continue;
-		} else {
-			web_server_accept(mini_sock->miniServerSock4, &rdSet);
-			web_server_accept(mini_sock->miniServerSock6, &rdSet);
-			web_server_accept(
-				mini_sock->miniServerSock6UlaGua, &rdSet);
-	#ifdef INCLUDE_CLIENT_APIS
-			ssdp_read(&mini_sock->ssdpReqSock4, &rdSet);
-			ssdp_read(&mini_sock->ssdpReqSock6, &rdSet);
-	#endif /* INCLUDE_CLIENT_APIS */
-			ssdp_read(&mini_sock->ssdpSock4, &rdSet);
-			ssdp_read(&mini_sock->ssdpSock6, &rdSet);
-			ssdp_read(&mini_sock->ssdpSock6UlaGua, &rdSet);
-			stopSock = receive_from_stopSock(
-				mini_sock->miniServerStopSock, &rdSet);
 		}
+
+		web_server_accept(mini_sock->miniServerSock4, &fds[1]);
+		web_server_accept(mini_sock->miniServerSock6, &fds[2]);
+		web_server_accept(mini_sock->miniServerSock6UlaGua, &fds[3]);
+
+	#ifdef INCLUDE_CLIENT_APIS
+		ssdp_read(&mini_sock->ssdpReqSock4, &fds[7]);
+		ssdp_read(&mini_sock->ssdpReqSock6, &fds[8]);
+	#endif /* INCLUDE_CLIENT_APIS */
+
+		ssdp_read(&mini_sock->ssdpSock4, &fds[4]);
+		ssdp_read(&mini_sock->ssdpSock6, &fds[5]);
+		ssdp_read(&mini_sock->ssdpSock6UlaGua, &fds[6]);
+
+		stopSock = receive_from_stopSock(
+			mini_sock->miniServerStopSock, &fds[0]);
 	}
 
 	/* shutdown connections */
@@ -869,6 +892,7 @@ static void RunMiniServer(
 	sock_close(mini_sock->ssdpReqSock4);
 	sock_close(mini_sock->ssdpReqSock6);
 	#endif /* INCLUDE_CLIENT_APIS */
+
 	/* Free mini_sock. */
 	free(mini_sock);
 	gMServState = MSERV_IDLE;
@@ -1334,22 +1358,22 @@ static int get_miniserver_stopsock(
 	return UPNP_E_SUCCESS;
 }
 
-static UPNP_INLINE void InitMiniServerSockArray(MiniServerSockArray *miniSocket)
+static UPNP_INLINE void InitMiniServerSockArray(MiniServerSockArray *mini_socket)
 {
-	miniSocket->miniServerSock4 = INVALID_SOCKET;
-	miniSocket->miniServerSock6 = INVALID_SOCKET;
-	miniSocket->miniServerSock6UlaGua = INVALID_SOCKET;
-	miniSocket->miniServerStopSock = INVALID_SOCKET;
-	miniSocket->ssdpSock4 = INVALID_SOCKET;
-	miniSocket->ssdpSock6 = INVALID_SOCKET;
-	miniSocket->ssdpSock6UlaGua = INVALID_SOCKET;
-	miniSocket->stopPort = 0u;
-	miniSocket->miniServerPort4 = 0u;
-	miniSocket->miniServerPort6 = 0u;
-	miniSocket->miniServerPort6UlaGua = 0u;
+	mini_socket->miniServerSock4 = INVALID_SOCKET;
+	mini_socket->miniServerSock6 = INVALID_SOCKET;
+	mini_socket->miniServerSock6UlaGua = INVALID_SOCKET;
+	mini_socket->miniServerStopSock = INVALID_SOCKET;
+	mini_socket->ssdpSock4 = INVALID_SOCKET;
+	mini_socket->ssdpSock6 = INVALID_SOCKET;
+	mini_socket->ssdpSock6UlaGua = INVALID_SOCKET;
+	mini_socket->stopPort = 0u;
+	mini_socket->miniServerPort4 = 0u;
+	mini_socket->miniServerPort6 = 0u;
+	mini_socket->miniServerPort6UlaGua = 0u;
 	#ifdef INCLUDE_CLIENT_APIS
-	miniSocket->ssdpReqSock4 = INVALID_SOCKET;
-	miniSocket->ssdpReqSock6 = INVALID_SOCKET;
+	mini_socket->ssdpReqSock4 = INVALID_SOCKET;
+	mini_socket->ssdpReqSock6 = INVALID_SOCKET;
 	#endif /* INCLUDE_CLIENT_APIS */
 }
 
@@ -1367,7 +1391,7 @@ int StartMiniServer(
 	int ret_code;
 	int count;
 	int max_count = 10000;
-	MiniServerSockArray *miniSocket;
+	MiniServerSockArray *mini_socket;
 	ThreadPoolJob job;
 
 	memset(&job, 0, sizeof(job));
@@ -1379,56 +1403,56 @@ int StartMiniServer(
 		/* miniserver running. */
 		return UPNP_E_INTERNAL_ERROR;
 	}
-	miniSocket = (MiniServerSockArray *)malloc(sizeof(MiniServerSockArray));
-	if (!miniSocket) {
+	mini_socket = (MiniServerSockArray *)malloc(sizeof(MiniServerSockArray));
+	if (!mini_socket) {
 		return UPNP_E_OUTOF_MEMORY;
 	}
-	InitMiniServerSockArray(miniSocket);
+	InitMiniServerSockArray(mini_socket);
 	#ifdef INTERNAL_WEB_SERVER
 	/* V4 and V6 http listeners. */
 	ret_code = get_miniserver_sockets(
-		miniSocket, *listen_port4, *listen_port6, *listen_port6UlaGua);
+		mini_socket, *listen_port4, *listen_port6, *listen_port6UlaGua);
 	if (ret_code != UPNP_E_SUCCESS) {
-		free(miniSocket);
+		free(mini_socket);
 		return ret_code;
 	}
 	#endif /* INTERNAL_WEB_SERVER */
 	/* Stop socket (To end miniserver processing). */
-	ret_code = get_miniserver_stopsock(miniSocket);
+	ret_code = get_miniserver_stopsock(mini_socket);
 	if (ret_code != UPNP_E_SUCCESS) {
-		sock_close(miniSocket->miniServerSock4);
-		sock_close(miniSocket->miniServerSock6);
-		sock_close(miniSocket->miniServerSock6UlaGua);
-		free(miniSocket);
+		sock_close(mini_socket->miniServerSock4);
+		sock_close(mini_socket->miniServerSock6);
+		sock_close(mini_socket->miniServerSock6UlaGua);
+		free(mini_socket);
 		return ret_code;
 	}
 	/* SSDP socket for discovery/advertising. */
-	ret_code = get_ssdp_sockets(miniSocket);
+	ret_code = get_ssdp_sockets(mini_socket);
 	if (ret_code != UPNP_E_SUCCESS) {
-		sock_close(miniSocket->miniServerSock4);
-		sock_close(miniSocket->miniServerSock6);
-		sock_close(miniSocket->miniServerSock6UlaGua);
-		sock_close(miniSocket->miniServerStopSock);
-		free(miniSocket);
+		sock_close(mini_socket->miniServerSock4);
+		sock_close(mini_socket->miniServerSock6);
+		sock_close(mini_socket->miniServerSock6UlaGua);
+		sock_close(mini_socket->miniServerStopSock);
+		free(mini_socket);
 		return ret_code;
 	}
-	TPJobInit(&job, (start_routine)RunMiniServer, (void *)miniSocket);
+	TPJobInit(&job, (start_routine)RunMiniServer, (void *)mini_socket);
 	TPJobSetPriority(&job, MED_PRIORITY);
 	TPJobSetFreeFunction(&job, (free_routine)free);
 	ret_code = ThreadPoolAddPersistent(&gMiniServerThreadPool, &job, NULL);
 	if (ret_code < 0) {
-		sock_close(miniSocket->miniServerSock4);
-		sock_close(miniSocket->miniServerSock6);
-		sock_close(miniSocket->miniServerSock6UlaGua);
-		sock_close(miniSocket->miniServerStopSock);
-		sock_close(miniSocket->ssdpSock4);
-		sock_close(miniSocket->ssdpSock6);
-		sock_close(miniSocket->ssdpSock6UlaGua);
+		sock_close(mini_socket->miniServerSock4);
+		sock_close(mini_socket->miniServerSock6);
+		sock_close(mini_socket->miniServerSock6UlaGua);
+		sock_close(mini_socket->miniServerStopSock);
+		sock_close(mini_socket->ssdpSock4);
+		sock_close(mini_socket->ssdpSock6);
+		sock_close(mini_socket->ssdpSock6UlaGua);
 	#ifdef INCLUDE_CLIENT_APIS
-		sock_close(miniSocket->ssdpReqSock4);
-		sock_close(miniSocket->ssdpReqSock6);
+		sock_close(mini_socket->ssdpReqSock4);
+		sock_close(mini_socket->ssdpReqSock6);
 	#endif /* INCLUDE_CLIENT_APIS */
-		free(miniSocket);
+		free(mini_socket);
 		return UPNP_E_OUTOF_MEMORY;
 	}
 	/* Wait for miniserver to start. */
@@ -1441,23 +1465,23 @@ int StartMiniServer(
 	}
 	if (count >= max_count) {
 		/* Took it too long to start that thread. */
-		sock_close(miniSocket->miniServerSock4);
-		sock_close(miniSocket->miniServerSock6);
-		sock_close(miniSocket->miniServerSock6UlaGua);
-		sock_close(miniSocket->miniServerStopSock);
-		sock_close(miniSocket->ssdpSock4);
-		sock_close(miniSocket->ssdpSock6);
-		sock_close(miniSocket->ssdpSock6UlaGua);
+		sock_close(mini_socket->miniServerSock4);
+		sock_close(mini_socket->miniServerSock6);
+		sock_close(mini_socket->miniServerSock6UlaGua);
+		sock_close(mini_socket->miniServerStopSock);
+		sock_close(mini_socket->ssdpSock4);
+		sock_close(mini_socket->ssdpSock6);
+		sock_close(mini_socket->ssdpSock6UlaGua);
 	#ifdef INCLUDE_CLIENT_APIS
-		sock_close(miniSocket->ssdpReqSock4);
-		sock_close(miniSocket->ssdpReqSock6);
+		sock_close(mini_socket->ssdpReqSock4);
+		sock_close(mini_socket->ssdpReqSock6);
 	#endif /* INCLUDE_CLIENT_APIS */
 		return UPNP_E_INTERNAL_ERROR;
 	}
 	#ifdef INTERNAL_WEB_SERVER
-	*listen_port4 = miniSocket->miniServerPort4;
-	*listen_port6 = miniSocket->miniServerPort6;
-	*listen_port6UlaGua = miniSocket->miniServerPort6UlaGua;
+	*listen_port4 = mini_socket->miniServerPort4;
+	*listen_port6 = mini_socket->miniServerPort6;
+	*listen_port6UlaGua = mini_socket->miniServerPort6UlaGua;
 	#endif /* INTERNAL_WEB_SERVER */
 
 	return UPNP_E_SUCCESS;

--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -697,8 +697,9 @@ static void web_server_accept(SOCKET listen_sock, struct pollfd *pfd)
 	if (listen_sock != INVALID_SOCKET && (pfd->revents & POLLIN)) {
 
 		clientLen = sizeof(clientAddr);
-		asock = accept(
-			listen_sock, (struct sockaddr *)&clientAddr, &clientLen);
+		asock = accept(listen_sock,
+			(struct sockaddr *)&clientAddr,
+			&clientLen);
 
 		if (asock == INVALID_SOCKET) {
 			strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
@@ -1370,7 +1371,8 @@ static int get_miniserver_stopsock(
 	return UPNP_E_SUCCESS;
 }
 
-static UPNP_INLINE void InitMiniServerSockArray(MiniServerSockArray *mini_socket)
+static UPNP_INLINE void InitMiniServerSockArray(
+	MiniServerSockArray *mini_socket)
 {
 	mini_socket->miniServerSock4 = INVALID_SOCKET;
 	mini_socket->miniServerSock6 = INVALID_SOCKET;
@@ -1415,7 +1417,8 @@ int StartMiniServer(
 		/* miniserver running. */
 		return UPNP_E_INTERNAL_ERROR;
 	}
-	mini_socket = (MiniServerSockArray *)malloc(sizeof(MiniServerSockArray));
+	mini_socket =
+		(MiniServerSockArray *)malloc(sizeof(MiniServerSockArray));
 	if (!mini_socket) {
 		return UPNP_E_OUTOF_MEMORY;
 	}

--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -63,11 +63,23 @@
 	#ifndef _WIN32
 		#include <netinet/tcp.h> /* TCP_NODELAY */
 	#endif
-	#include <poll.h>
 	#include <stdio.h>
 	#include <stdlib.h>
 	#include <string.h>
 	#include <sys/types.h>
+
+	#ifdef _WIN32
+		#include <winsock2.h>
+		#include <ws2tcpip.h>
+	#else
+		#include <poll.h>
+	#endif
+
+	#ifdef _WIN32
+		#define _poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
+	#else
+		#define _poll(fds, nfds, timeout) poll(fds, nfds, timeout)
+	#endif
 
 	/*! . */
 	#define APPLICATION_LISTENING_PORT 49152
@@ -843,7 +855,7 @@ static void RunMiniServer(
 	#endif /* INCLUDE_CLIENT_APIS */
 
 		/* poll() */
-		ret = poll(fds, nfds, -1);
+		ret = _poll(fds, nfds, -1);
 
 		if (ret < 0 && errno == EINTR) {
 			continue;

--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -68,16 +68,8 @@
 	#include <string.h>
 	#include <sys/types.h>
 
-	#ifdef _WIN32
-		#include <winsock2.h>
-		#include <ws2tcpip.h>
-	#else
+	#ifndef _WIN32
 		#include <poll.h>
-	#endif
-
-	#ifdef _WIN32
-		#define _poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
-	#else
 		#define _poll(fds, nfds, timeout) poll(fds, nfds, timeout)
 	#endif
 
@@ -673,6 +665,14 @@ void shutdown_all_active_connections(void)
 	/*--------------------------------------------------------------------*/
 }
 
+	#ifdef _WIN32
+static UPNP_INLINE void fdset_if_valid(SOCKET sock, fd_set *set)
+{
+	if (sock != INVALID_SOCKET) {
+		FD_SET(sock, set);
+	}
+}
+	#else
 static UPNP_INLINE void pollfd_if_valid(
 	SOCKET sock, struct pollfd *pfd, short events)
 {
@@ -684,11 +684,68 @@ static UPNP_INLINE void pollfd_if_valid(
 		pfd->fd = -1;
 	}
 }
+	#endif /* _WIN32 */
 
+	#ifdef _WIN32
+static void ssdp_read(SOCKET *read_sock, fd_set *set)
+{
+	if (*read_sock != INVALID_SOCKET && FD_ISSET(*read_sock, set)) {
+		int ret = readFromSSDPSocket(*read_sock);
+		if (ret != 0) {
+			UpnpPrintf(UPNP_INFO,
+				MSERV,
+				__FILE__,
+				__LINE__,
+				"miniserver: Error in readFromSSDPSocket(%d): "
+				"closing socket\n",
+				*read_sock);
+			sock_close(*read_sock);
+			*read_sock = INVALID_SOCKET;
+		}
+	}
+}
+static void web_server_accept(SOCKET listen_sock, fd_set *set)
+{
+		/*--------------------------------------------------------------------*/
+		#ifdef INTERNAL_WEB_SERVER
+	SOCKET asock;
+	socklen_t clientLen;
+	struct sockaddr_storage clientAddr;
+	char errorBuffer[ERROR_BUFFER_LEN];
+
+	if (listen_sock != INVALID_SOCKET && FD_ISSET(listen_sock, set)) {
+		clientLen = sizeof(clientAddr);
+		asock = accept(listen_sock,
+			(struct sockaddr *)&clientAddr,
+			&clientLen);
+
+		if (asock == INVALID_SOCKET) {
+			strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
+			UpnpPrintf(UPNP_INFO,
+				MSERV,
+				__FILE__,
+				__LINE__,
+				"miniserver: Error in accept(): %s\n",
+				errorBuffer);
+		} else {
+			const int on = 1;
+			setsockopt(asock,
+				IPPROTO_TCP,
+				TCP_NODELAY,
+				(const char *)&on,
+				sizeof(on));
+			schedule_request_job(
+				asock, (struct sockaddr *)&clientAddr);
+		}
+	}
+		#endif /* INTERNAL_WEB_SERVER */
+	/*--------------------------------------------------------------------*/
+}
+	#else /* _WIN32 */
 static void web_server_accept(SOCKET listen_sock, struct pollfd *pfd)
 {
-	/*--------------------------------------------------------------------*/
-	#ifdef INTERNAL_WEB_SERVER
+		/*--------------------------------------------------------------------*/
+		#ifdef INTERNAL_WEB_SERVER
 	SOCKET asock;
 	socklen_t clientLen;
 	struct sockaddr_storage clientAddr;
@@ -720,10 +777,12 @@ static void web_server_accept(SOCKET listen_sock, struct pollfd *pfd)
 				asock, (struct sockaddr *)&clientAddr);
 		}
 	}
-	#endif /* INTERNAL_WEB_SERVER */
+		#endif /* INTERNAL_WEB_SERVER */
 	/*--------------------------------------------------------------------*/
 }
+	#endif	       /* _WIN32 */
 
+	#ifndef _WIN32
 static void ssdp_read(SOCKET *read_sock, struct pollfd *pfd)
 {
 	if (*read_sock != INVALID_SOCKET && (pfd->revents & POLLIN)) {
@@ -742,7 +801,68 @@ static void ssdp_read(SOCKET *read_sock, struct pollfd *pfd)
 		}
 	}
 }
+	#endif /* _WIN32 */
 
+	#ifdef _WIN32
+static int receive_from_stopSock(SOCKET ssock, fd_set *set)
+{
+	ssize_t byteReceived;
+	socklen_t clientLen;
+	struct sockaddr_storage clientAddr;
+	char requestBuf[256];
+	char buf_ntop[INET6_ADDRSTRLEN];
+
+	if (ssock != INVALID_SOCKET && FD_ISSET(ssock, set)) {
+		clientLen = sizeof(clientAddr);
+		memset(&clientAddr, 0, sizeof(clientAddr));
+
+		byteReceived = recvfrom(ssock,
+			requestBuf,
+			(size_t)25,
+			0,
+			(struct sockaddr *)&clientAddr,
+			&clientLen);
+
+		if (byteReceived > 0) {
+			requestBuf[byteReceived] = '\0';
+
+			/* Convert IPv4 address to string */
+			inet_ntop(AF_INET,
+				&((struct sockaddr_in *)&clientAddr)->sin_addr,
+				buf_ntop,
+				sizeof(buf_ntop));
+
+			UpnpPrintf(UPNP_INFO,
+				MSERV,
+				__FILE__,
+				__LINE__,
+				"Received response: %s From host %s \n",
+				requestBuf,
+				buf_ntop);
+
+			UpnpPrintf(UPNP_PACKET,
+				MSERV,
+				__FILE__,
+				__LINE__,
+				"Received multicast packet: \n %s\n",
+				requestBuf);
+
+			if (strstr(requestBuf, "ShutDown") != NULL) {
+				return 1;
+			}
+		} else {
+			UpnpPrintf(UPNP_INFO,
+				MSERV,
+				__FILE__,
+				__LINE__,
+				"miniserver: stopSock Error, aborting...\n");
+			return 1;
+		}
+	}
+
+	return 0;
+}
+	#else  /* _WIN32 */
 static int receive_from_stopSock(SOCKET ssock, struct pollfd *pfd)
 {
 	ssize_t byteReceived;
@@ -803,6 +923,7 @@ static int receive_from_stopSock(SOCKET ssock, struct pollfd *pfd)
 
 	return 0;
 }
+	#endif /* _WIN32 */
 
 	#define MINI_SERVER_MAX_PFDS 9
 /*!
@@ -819,13 +940,75 @@ static void RunMiniServer(
 	char errorBuffer[ERROR_BUFFER_LEN];
 	int ret = 0;
 	int stopSock = 0;
+	#ifdef _WIN32
+	fd_set expSet;
+	fd_set rdSet;
+	SOCKET maxMiniSock;
 
+	maxMiniSock = 0;
+	maxMiniSock = max(maxMiniSock, mini_sock->miniServerSock4);
+	maxMiniSock = max(maxMiniSock, mini_sock->miniServerSock6);
+	maxMiniSock = max(maxMiniSock, mini_sock->miniServerSock6UlaGua);
+	maxMiniSock = max(maxMiniSock, mini_sock->miniServerStopSock);
+	maxMiniSock = max(maxMiniSock, mini_sock->ssdpSock4);
+	maxMiniSock = max(maxMiniSock, mini_sock->ssdpSock6);
+	maxMiniSock = max(maxMiniSock, mini_sock->ssdpSock6UlaGua);
+		#ifdef INCLUDE_CLIENT_APIS
+	maxMiniSock = max(maxMiniSock, mini_sock->ssdpReqSock4);
+	maxMiniSock = max(maxMiniSock, mini_sock->ssdpReqSock6);
+		#endif /* INCLUDE_CLIENT_APIS */
+	++maxMiniSock;
+	#else  /* _WIN32 */
 	struct pollfd fds[MINI_SERVER_MAX_PFDS];
 	int nfds = 0;
+	#endif /* _WIN32 */
 
 	gMServState = MSERV_RUNNING;
 
 	while (!stopSock) {
+	#ifdef _WIN32
+		FD_ZERO(&rdSet);
+		FD_ZERO(&expSet);
+		FD_SET(mini_sock->miniServerStopSock, &expSet);
+		FD_SET(mini_sock->miniServerStopSock, &rdSet);
+		fdset_if_valid(mini_sock->miniServerSock4, &rdSet);
+		fdset_if_valid(mini_sock->miniServerSock6, &rdSet);
+		fdset_if_valid(mini_sock->miniServerSock6UlaGua, &rdSet);
+		fdset_if_valid(mini_sock->ssdpSock4, &rdSet);
+		fdset_if_valid(mini_sock->ssdpSock6, &rdSet);
+		fdset_if_valid(mini_sock->ssdpSock6UlaGua, &rdSet);
+		#ifdef INCLUDE_CLIENT_APIS
+		fdset_if_valid(mini_sock->ssdpReqSock4, &rdSet);
+		fdset_if_valid(mini_sock->ssdpReqSock6, &rdSet);
+		#endif /* INCLUDE_CLIENT_APIS */
+		/* select() */
+		ret = select((int)maxMiniSock, &rdSet, NULL, &expSet, NULL);
+		if (ret == SOCKET_ERROR && errno == EINTR) {
+			continue;
+		}
+		if (ret == SOCKET_ERROR) {
+			strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
+			UpnpPrintf(UPNP_CRITICAL,
+				SSDP,
+				__FILE__,
+				__LINE__,
+				"Error in select(): %s\n",
+				errorBuffer);
+			continue;
+		}
+		web_server_accept(mini_sock->miniServerSock4, &rdSet);
+		web_server_accept(mini_sock->miniServerSock6, &rdSet);
+		web_server_accept(mini_sock->miniServerSock6UlaGua, &rdSet);
+		#ifdef INCLUDE_CLIENT_APIS
+		ssdp_read(&mini_sock->ssdpReqSock4, &rdSet);
+		ssdp_read(&mini_sock->ssdpReqSock6, &rdSet);
+		#endif /* INCLUDE_CLIENT_APIS */
+		ssdp_read(&mini_sock->ssdpSock4, &rdSet);
+		ssdp_read(&mini_sock->ssdpSock6, &rdSet);
+		ssdp_read(&mini_sock->ssdpSock6UlaGua, &rdSet);
+		stopSock = receive_from_stopSock(
+			mini_sock->miniServerStopSock, &rdSet);
+	#else /* _WIN32 */
 		nfds = 0;
 
 		/* Stop socket: watch for read + error */
@@ -849,11 +1032,11 @@ static void RunMiniServer(
 		pollfd_if_valid(
 			mini_sock->ssdpSock6UlaGua, &fds[nfds++], POLLIN);
 
-	#ifdef INCLUDE_CLIENT_APIS
+		#ifdef INCLUDE_CLIENT_APIS
 		pollfd_if_valid(mini_sock->ssdpReqSock4, &fds[nfds++], POLLIN);
 
 		pollfd_if_valid(mini_sock->ssdpReqSock6, &fds[nfds++], POLLIN);
-	#endif /* INCLUDE_CLIENT_APIS */
+		#endif /* INCLUDE_CLIENT_APIS */
 
 		/* poll() */
 		ret = _poll(fds, nfds, -1);
@@ -877,10 +1060,10 @@ static void RunMiniServer(
 		web_server_accept(mini_sock->miniServerSock6, &fds[2]);
 		web_server_accept(mini_sock->miniServerSock6UlaGua, &fds[3]);
 
-	#ifdef INCLUDE_CLIENT_APIS
+		#ifdef INCLUDE_CLIENT_APIS
 		ssdp_read(&mini_sock->ssdpReqSock4, &fds[7]);
 		ssdp_read(&mini_sock->ssdpReqSock6, &fds[8]);
-	#endif /* INCLUDE_CLIENT_APIS */
+		#endif /* INCLUDE_CLIENT_APIS */
 
 		ssdp_read(&mini_sock->ssdpSock4, &fds[4]);
 		ssdp_read(&mini_sock->ssdpSock6, &fds[5]);
@@ -888,6 +1071,7 @@ static void RunMiniServer(
 
 		stopSock = receive_from_stopSock(
 			mini_sock->miniServerStopSock, &fds[0]);
+	#endif	       /* _WIN32 */
 	}
 
 	/* shutdown connections */

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -55,18 +55,21 @@
 #include <inttypes.h>
 #include <stdarg.h>
 #include <string.h>
-#include <poll.h>
 
 #include "posix_overwrites.h" // IWYU pragma: keep
 
 #ifdef _WIN32
 	#include <malloc.h>
+	#include <winsock2.h>
+	#include <ws2tcpip.h>
 	#define fseeko fseek
 	#if defined(_MSC_VER) && _MSC_VER < 1900
 		#define snprintf _snprintf
 	#endif
+	#define _poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
 #else /* _WIN32 */
 	#include <arpa/inet.h>
+	#include <poll.h>
 	#include <sys/time.h>
 	#include <sys/types.h>
 	#include <sys/utsname.h>
@@ -75,6 +78,7 @@
 		(!defined(__USE_FILE_OFFSET64) || __ANDROID_API__ < 24)
 		#define fseeko fseek
 	#endif
+	#define _poll(fds, nfds, timeout) poll(fds, nfds, timeout)
 #endif /* _WIN32 */
 
 /*
@@ -99,39 +103,46 @@ const int CHUNK_TAIL_SIZE = 10;
  *
  * \return 0 if successful, else -1.
  */
-static int Check_Connect_And_Wait_Connection(SOCKET sock, int connect_res) {
-    struct timeval tmvTimeout = {DEFAULT_TCP_CONNECT_TIMEOUT, 0};
-    int result;
-    struct pollfd fds[1];
+static int Check_Connect_And_Wait_Connection(SOCKET sock, int connect_res)
+{
+	struct timeval tmvTimeout = {DEFAULT_TCP_CONNECT_TIMEOUT, 0};
+	int result;
+	struct pollfd fds[1];
 
-    fds[0].fd = sock;
-    fds[0].events = POLLOUT;
+	fds[0].fd = sock;
+	fds[0].events = POLLOUT;
 
-    if (connect_res < 0) {
-        result = poll(fds, 1, tmvTimeout.tv_sec * 1000 + tmvTimeout.tv_usec / 1000);
+	if (connect_res < 0) {
+		result = poll(fds,
+			1,
+			tmvTimeout.tv_sec * 1000 + tmvTimeout.tv_usec / 1000);
 
-        if (result < 0) {
-            /* Error in poll */
-            return -1;
-        } else if (result == 0) {
-            /* Timeout */
-            return -1;
-        } else {
-            int valopt = 0;
-            socklen_t len = sizeof(valopt);
+		if (result < 0) {
+			/* Error in poll */
+			return -1;
+		} else if (result == 0) {
+			/* Timeout */
+			return -1;
+		} else {
+			int valopt = 0;
+			socklen_t len = sizeof(valopt);
 
-            /* Check if the socket is now writable (connected) */
-            if (getsockopt(sock, SOL_SOCKET, SO_ERROR, (void *)&valopt, &len) < 0) {
-                /* Failed to read delayed error */
-                return -1;
-            } else if (valopt) {
-                /* Delayed error = valopt */
-                return -1;
-            }
-        }
-    }
+			/* Check if the socket is now writable (connected) */
+			if (getsockopt(sock,
+				    SOL_SOCKET,
+				    SO_ERROR,
+				    (void *)&valopt,
+				    &len) < 0) {
+				/* Failed to read delayed error */
+				return -1;
+			} else if (valopt) {
+				/* Delayed error = valopt */
+				return -1;
+			}
+		}
+	}
 
-    return 0;
+	return 0;
 }
 #endif /* UPNP_ENABLE_BLOCKING_TCP_CONNECTIONS */
 
@@ -1554,7 +1565,7 @@ int http_ReadHttpResponse(void *Handle, char *buf, size_t *size, int timeout)
 	if (*size > 0) {
 		memcpy(buf,
 			&handle->response.msg.msg
-				.buf[handle->response.entity_start_position],
+				 .buf[handle->response.entity_start_position],
 			*size);
 		membuffer_delete(&handle->response.msg.msg,
 			handle->response.entity_start_position,

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -55,6 +55,7 @@
 #include <inttypes.h>
 #include <stdarg.h>
 #include <string.h>
+#include <poll.h>
 
 #include "posix_overwrites.h" // IWYU pragma: keep
 
@@ -98,61 +99,39 @@ const int CHUNK_TAIL_SIZE = 10;
  *
  * \return 0 if successful, else -1.
  */
-static int Check_Connect_And_Wait_Connection(
-	/*! [in] socket. */
-	SOCKET sock,
-	/*! [in] result of connect. */
-	int connect_res)
-{
-	struct timeval tmvTimeout = {DEFAULT_TCP_CONNECT_TIMEOUT, 0};
-	int result;
-	#ifdef _WIN32
-	struct fd_set fdSet;
-	#else
-	fd_set fdSet;
-	#endif
-	FD_ZERO(&fdSet);
-	FD_SET(sock, &fdSet);
+static int Check_Connect_And_Wait_Connection(SOCKET sock, int connect_res) {
+    struct timeval tmvTimeout = {DEFAULT_TCP_CONNECT_TIMEOUT, 0};
+    int result;
+    struct pollfd fds[1];
 
-	if (connect_res < 0) {
-	#ifdef _WIN32
-		if (WSAEWOULDBLOCK == WSAGetLastError()) {
-	#else
-		if (EINPROGRESS == errno) {
-	#endif
-			result = select(
-				(int)sock + 1, NULL, &fdSet, NULL, &tmvTimeout);
-			if (result < 0) {
-	#ifdef _WIN32
-					/* WSAGetLastError(); */
-	#else
-					/* errno */
-	#endif
-				return -1;
-			} else if (result == 0) {
-				/* timeout */
-				return -1;
-	#ifndef _WIN32
-			} else {
-				int valopt = 0;
-				socklen_t len = sizeof(valopt);
-				if (getsockopt(sock,
-					    SOL_SOCKET,
-					    SO_ERROR,
-					    (void *)&valopt,
-					    &len) < 0) {
-					/* failed to read delayed error */
-					return -1;
-				} else if (valopt) {
-					/* delayed error = valopt */
-					return -1;
-				}
-	#endif
-			}
-		}
-	}
+    fds[0].fd = sock;
+    fds[0].events = POLLOUT;
 
-	return 0;
+    if (connect_res < 0) {
+        result = poll(fds, 1, tmvTimeout.tv_sec * 1000 + tmvTimeout.tv_usec / 1000);
+
+        if (result < 0) {
+            /* Error in poll */
+            return -1;
+        } else if (result == 0) {
+            /* Timeout */
+            return -1;
+        } else {
+            int valopt = 0;
+            socklen_t len = sizeof(valopt);
+
+            /* Check if the socket is now writable (connected) */
+            if (getsockopt(sock, SOL_SOCKET, SO_ERROR, (void *)&valopt, &len) < 0) {
+                /* Failed to read delayed error */
+                return -1;
+            } else if (valopt) {
+                /* Delayed error = valopt */
+                return -1;
+            }
+        }
+    }
+
+    return 0;
 }
 #endif /* UPNP_ENABLE_BLOCKING_TCP_CONNECTIONS */
 

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -113,7 +113,7 @@ static int Check_Connect_And_Wait_Connection(SOCKET sock, int connect_res)
 	fds[0].events = POLLOUT;
 
 	if (connect_res < 0) {
-		result = poll(fds,
+		result = _poll(fds,
 			1,
 			tmvTimeout.tv_sec * 1000 + tmvTimeout.tv_usec / 1000);
 
@@ -1565,7 +1565,7 @@ int http_ReadHttpResponse(void *Handle, char *buf, size_t *size, int timeout)
 	if (*size > 0) {
 		memcpy(buf,
 			&handle->response.msg.msg
-				 .buf[handle->response.entity_start_position],
+				.buf[handle->response.entity_start_position],
 			*size);
 		membuffer_delete(&handle->response.msg.msg,
 			handle->response.entity_start_position,

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -66,7 +66,6 @@
 	#if defined(_MSC_VER) && _MSC_VER < 1900
 		#define snprintf _snprintf
 	#endif
-	#define _poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
 #else /* _WIN32 */
 	#include <arpa/inet.h>
 	#include <poll.h>
@@ -107,37 +106,43 @@ static int Check_Connect_And_Wait_Connection(SOCKET sock, int connect_res)
 {
 	struct timeval tmvTimeout = {DEFAULT_TCP_CONNECT_TIMEOUT, 0};
 	int result;
-	struct pollfd fds[1];
-
-	fds[0].fd = sock;
-	fds[0].events = POLLOUT;
+	#ifdef _WIN32
+	struct fd_set fdSet;
+	#else
+	fd_set fdSet;
+	#endif
+	FD_ZERO(&fdSet);
+	FD_SET(sock, &fdSet);
 
 	if (connect_res < 0) {
-		result = _poll(fds,
-			1,
-			tmvTimeout.tv_sec * 1000 + tmvTimeout.tv_usec / 1000);
-
-		if (result < 0) {
-			/* Error in poll */
-			return -1;
-		} else if (result == 0) {
-			/* Timeout */
-			return -1;
-		} else {
-			int valopt = 0;
-			socklen_t len = sizeof(valopt);
-
-			/* Check if the socket is now writable (connected) */
-			if (getsockopt(sock,
-				    SOL_SOCKET,
-				    SO_ERROR,
-				    (void *)&valopt,
-				    &len) < 0) {
-				/* Failed to read delayed error */
+	#ifdef _WIN32
+		if (WSAEWOULDBLOCK == WSAGetLastError()) {
+	#else
+		if (EINPROGRESS == errno) {
+	#endif
+			result = select(
+				(int)sock + 1, NULL, &fdSet, NULL, &tmvTimeout);
+			if (result < 0) {
 				return -1;
-			} else if (valopt) {
-				/* Delayed error = valopt */
+			} else if (result == 0) {
+				/* timeout */
 				return -1;
+	#ifndef _WIN32
+			} else {
+				int valopt = 0;
+				socklen_t len = sizeof(valopt);
+				if (getsockopt(sock,
+					    SOL_SOCKET,
+					    SO_ERROR,
+					    (void *)&valopt,
+					    &len) < 0) {
+					/* failed to read delayed error */
+					return -1;
+				} else if (valopt) {
+					/* delayed error = valopt */
+					return -1;
+				}
+	#endif
 			}
 		}
 	}

--- a/upnp/src/genlib/net/sock.c
+++ b/upnp/src/genlib/net/sock.c
@@ -56,7 +56,19 @@
 #include <fcntl.h> /* for F_GETFL, F_SETFL, O_NONBLOCK */
 #include <string.h>
 #include <time.h>
-#include <poll.h>
+
+#ifdef _WIN32
+	#include <winsock2.h>
+	#include <ws2tcpip.h>
+#else
+	#include <poll.h>
+#endif
+
+#ifdef _WIN32
+	#define _poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
+#else
+	#define _poll(fds, nfds, timeout) poll(fds, nfds, timeout)
+#endif
 
 #ifdef UPNP_ENABLE_OPEN_SSL
 	#include <openssl/ssl.h>
@@ -157,42 +169,48 @@ int sock_destroy(SOCKINFO *info, int ShutdownMethod)
  *	\li \c UPNP_E_TIMEDOUT - Timeout
  *	\li \c UPNP_E_SOCKET_ERROR - Error on socket calls
  */
-static int sock_read_write(SOCKINFO *info, char *buffer, size_t bufsize, int *timeoutSecs, int bRead) {
-    int retCode;
-    struct pollfd fds[1];
-    time_t start_time = time(NULL);
-    SOCKET sockfd = info->socket;
-    long bytes_sent = 0;
-    size_t byte_left = 0;
-    ssize_t num_written;
-    long numBytes;
+static int sock_read_write(SOCKINFO *info,
+	char *buffer,
+	size_t bufsize,
+	int *timeoutSecs,
+	int bRead)
+{
+	int retCode;
+	struct pollfd fds[1];
+	time_t start_time = time(NULL);
+	SOCKET sockfd = info->socket;
+	long bytes_sent = 0;
+	size_t byte_left = 0;
+	ssize_t num_written;
+	long numBytes;
 
-    fds[0].fd = sockfd;
-    fds[0].events = (bRead ? POLLIN : POLLOUT);
+	fds[0].fd = sockfd;
+	fds[0].events = (bRead ? POLLIN : POLLOUT);
 
-    while (1) {
-        int timeoutMillis = (*timeoutSecs < 0) ? -1 : (*timeoutSecs * 1000);
+	while (1) {
+		int timeoutMillis =
+			(*timeoutSecs < 0) ? -1 : (*timeoutSecs * 1000);
 
-        retCode = poll(fds, 1, timeoutMillis);
+		retCode = poll(fds, 1, timeoutMillis);
 
-        if (retCode == 0)
-            return UPNP_E_TIMEDOUT;
-        else if (retCode == -1) {
-            if (errno == EINTR)
-                continue;
-            return UPNP_E_SOCKET_ERROR;
-        } else
-            /* read or write. */
-            break;
-    }
+		if (retCode == 0)
+			return UPNP_E_TIMEDOUT;
+		else if (retCode == -1) {
+			if (errno == EINTR)
+				continue;
+			return UPNP_E_SOCKET_ERROR;
+		} else
+			/* read or write. */
+			break;
+	}
 
 #ifdef SO_NOSIGPIPE
-    {
-        int old;
-        int set = 1;
-        socklen_t olen = sizeof(old);
-        getsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &old, &olen);
-        setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &set, sizeof(set));
+	{
+		int old;
+		int set = 1;
+		socklen_t olen = sizeof(old);
+		getsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &old, &olen);
+		setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &set, sizeof(set));
 #endif
 		if (bRead) {
 #ifdef UPNP_ENABLE_OPEN_SSL
@@ -202,7 +220,10 @@ static int sock_read_write(SOCKINFO *info, char *buffer, size_t bufsize, int *ti
 			} else {
 #endif
 				/* read data. */
-				numBytes = (long)recv(sockfd, buffer, (int)bufsize, MSG_NOSIGNAL);
+				numBytes = (long)recv(sockfd,
+					buffer,
+					(int)bufsize,
+					MSG_NOSIGNAL);
 #ifdef UPNP_ENABLE_OPEN_SSL
 			}
 #endif

--- a/upnp/src/genlib/net/sock.c
+++ b/upnp/src/genlib/net/sock.c
@@ -56,6 +56,7 @@
 #include <fcntl.h> /* for F_GETFL, F_SETFL, O_NONBLOCK */
 #include <string.h>
 #include <time.h>
+#include <poll.h>
 
 #ifdef UPNP_ENABLE_OPEN_SSL
 	#include <openssl/ssl.h>
@@ -156,85 +157,59 @@ int sock_destroy(SOCKINFO *info, int ShutdownMethod)
  *	\li \c UPNP_E_TIMEDOUT - Timeout
  *	\li \c UPNP_E_SOCKET_ERROR - Error on socket calls
  */
-static int sock_read_write(
-	/*! [in] Socket Information Object. */
-	SOCKINFO *info,
-	/*! [out] Buffer to get data to or send data from. */
-	char *buffer,
-	/*! [in] Size of the buffer. */
-	size_t bufsize,
-	/*! [in] timeout value. */
-	int *timeoutSecs,
-	/*! [in] Boolean value specifying read or write option. */
-	int bRead)
-{
-	int retCode;
-	fd_set readSet;
-	fd_set writeSet;
-	struct timeval timeout;
-	long numBytes;
-	time_t start_time = time(NULL);
-	SOCKET sockfd = info->socket;
-	long bytes_sent = 0;
-	size_t byte_left = 0;
-	ssize_t num_written;
+static int sock_read_write(SOCKINFO *info, char *buffer, size_t bufsize, int *timeoutSecs, int bRead) {
+    int retCode;
+    struct pollfd fds[1];
+    time_t start_time = time(NULL);
+    SOCKET sockfd = info->socket;
+    long bytes_sent = 0;
+    size_t byte_left = 0;
+    ssize_t num_written;
+    long numBytes;
 
-	FD_ZERO(&readSet);
-	FD_ZERO(&writeSet);
-	if (bRead)
-		FD_SET(sockfd, &readSet);
-	else
-		FD_SET(sockfd, &writeSet);
-	timeout.tv_sec = *timeoutSecs;
-	timeout.tv_usec = 0;
-	while (1) {
-		if (*timeoutSecs < 0)
-			retCode = select((int)sockfd + 1,
-				&readSet,
-				&writeSet,
-				NULL,
-				NULL);
-		else
-			retCode = select((int)sockfd + 1,
-				&readSet,
-				&writeSet,
-				NULL,
-				&timeout);
-		if (retCode == 0)
-			return UPNP_E_TIMEDOUT;
-		if (retCode == -1) {
-			if (errno == EINTR)
-				continue;
-			return UPNP_E_SOCKET_ERROR;
-		} else
-			/* read or write. */
-			break;
-	}
+    fds[0].fd = sockfd;
+    fds[0].events = (bRead ? POLLIN : POLLOUT);
+
+    while (1) {
+        int timeoutMillis = (*timeoutSecs < 0) ? -1 : (*timeoutSecs * 1000);
+
+        retCode = poll(fds, 1, timeoutMillis);
+
+        if (retCode == 0)
+            return UPNP_E_TIMEDOUT;
+        else if (retCode == -1) {
+            if (errno == EINTR)
+                continue;
+            return UPNP_E_SOCKET_ERROR;
+        } else
+            /* read or write. */
+            break;
+    }
+
 #ifdef SO_NOSIGPIPE
-	{
-		int old;
-		int set = 1;
-		socklen_t olen = sizeof(old);
-		getsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &old, &olen);
-		setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &set, sizeof(set));
+    {
+        int old;
+        int set = 1;
+        socklen_t olen = sizeof(old);
+        getsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &old, &olen);
+        setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &set, sizeof(set));
 #endif
 		if (bRead) {
 #ifdef UPNP_ENABLE_OPEN_SSL
 			if (info->ssl) {
 				numBytes = (long)SSL_read(
-					info->ssl, buffer, (size_t)bufsize);
+					info->ssl, buffer, bufsize);
 			} else {
 #endif
 				/* read data. */
-				numBytes = (long)recv(
-					sockfd, buffer, bufsize, MSG_NOSIGNAL);
+				numBytes = (long)recv(sockfd, buffer, (int)bufsize, MSG_NOSIGNAL);
 #ifdef UPNP_ENABLE_OPEN_SSL
 			}
 #endif
 		} else {
 			byte_left = bufsize;
 			bytes_sent = 0;
-			while (byte_left != (size_t)0) {
+			while (byte_left != 0) {
 #ifdef UPNP_ENABLE_OPEN_SSL
 				if (info->ssl) {
 					num_written = SSL_write(info->ssl,

--- a/upnp/src/genlib/net/sock.c
+++ b/upnp/src/genlib/net/sock.c
@@ -191,7 +191,7 @@ static int sock_read_write(SOCKINFO *info,
 		int timeoutMillis =
 			(*timeoutSecs < 0) ? -1 : (*timeoutSecs * 1000);
 
-		retCode = poll(fds, 1, timeoutMillis);
+		retCode = _poll(fds, 1, timeoutMillis);
 
 		if (retCode == 0)
 			return UPNP_E_TIMEDOUT;

--- a/upnp/src/genlib/net/sock.c
+++ b/upnp/src/genlib/net/sock.c
@@ -57,16 +57,8 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef _WIN32
-	#include <winsock2.h>
-	#include <ws2tcpip.h>
-#else
+#ifndef _WIN32
 	#include <poll.h>
-#endif
-
-#ifdef _WIN32
-	#define _poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
-#else
 	#define _poll(fds, nfds, timeout) poll(fds, nfds, timeout)
 #endif
 
@@ -176,7 +168,6 @@ static int sock_read_write(SOCKINFO *info,
 	int bRead)
 {
 	int retCode;
-	struct pollfd fds[1];
 	time_t start_time = time(NULL);
 	SOCKET sockfd = info->socket;
 	long bytes_sent = 0;
@@ -184,25 +175,62 @@ static int sock_read_write(SOCKINFO *info,
 	ssize_t num_written;
 	long numBytes;
 
-	fds[0].fd = sockfd;
-	fds[0].events = (bRead ? POLLIN : POLLOUT);
-
-	while (1) {
-		int timeoutMillis =
-			(*timeoutSecs < 0) ? -1 : (*timeoutSecs * 1000);
-
-		retCode = _poll(fds, 1, timeoutMillis);
-
-		if (retCode == 0)
-			return UPNP_E_TIMEDOUT;
-		else if (retCode == -1) {
-			if (errno == EINTR)
-				continue;
-			return UPNP_E_SOCKET_ERROR;
-		} else
-			/* read or write. */
-			break;
+#ifndef _WIN32
+	{
+		struct pollfd fds[1];
+		fds[0].fd = sockfd;
+		fds[0].events = (bRead ? POLLIN : POLLOUT);
+		while (1) {
+			int timeoutMillis =
+				(*timeoutSecs < 0) ? -1 : (*timeoutSecs * 1000);
+			retCode = _poll(fds, 1, timeoutMillis);
+			if (retCode == 0)
+				return UPNP_E_TIMEDOUT;
+			else if (retCode == -1) {
+				if (errno == EINTR)
+					continue;
+				return UPNP_E_SOCKET_ERROR;
+			} else
+				break;
+		}
 	}
+#else  /* _WIN32 */
+	{
+		fd_set readSet;
+		fd_set writeSet;
+		struct timeval timeout;
+		FD_ZERO(&readSet);
+		FD_ZERO(&writeSet);
+		if (bRead)
+			FD_SET(sockfd, &readSet);
+		else
+			FD_SET(sockfd, &writeSet);
+		timeout.tv_sec = *timeoutSecs;
+		timeout.tv_usec = 0;
+		while (1) {
+			if (*timeoutSecs < 0)
+				retCode = select((int)sockfd + 1,
+					&readSet,
+					&writeSet,
+					NULL,
+					NULL);
+			else
+				retCode = select((int)sockfd + 1,
+					&readSet,
+					&writeSet,
+					NULL,
+					&timeout);
+			if (retCode == 0)
+				return UPNP_E_TIMEDOUT;
+			if (retCode == -1) {
+				if (errno == EINTR)
+					continue;
+				return UPNP_E_SOCKET_ERROR;
+			} else
+				break;
+		}
+	}
+#endif /* _WIN32 */
 
 #ifdef SO_NOSIGPIPE
 	{

--- a/upnp/src/ssdp/ssdp_ctrlpt.c
+++ b/upnp/src/ssdp/ssdp_ctrlpt.c
@@ -40,7 +40,19 @@
 #include "config.h"
 
 #include "upnputil.h"
-#include <poll.h>
+
+#ifdef _WIN32
+	#include <winsock2.h>
+	#include <ws2tcpip.h>
+#else
+	#include <poll.h>
+#endif
+
+#ifdef _WIN32
+	#define _poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
+#else
+	#define _poll(fds, nfds, timeout) poll(fds, nfds, timeout)
+#endif
 
 #ifdef INCLUDE_CLIENT_APIS
 	#if EXCLUDE_SSDP == 0
@@ -662,55 +674,101 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 	/* End of lock */
 
 	struct pollfd fds[2];
-    int nfds = 0;
+	int nfds = 0;
 
-    if (gSsdpReqSocket4 != INVALID_SOCKET) {
-        setsockopt(gSsdpReqSocket4, IPPROTO_IP, IP_MULTICAST_IF, (char *)&addrv4, sizeof(addrv4));
-        fds[nfds].fd = gSsdpReqSocket4;
-        fds[nfds].events = POLLOUT;
-        nfds++;
-    }
-#ifdef UPNP_ENABLE_IPV6
-    if (gSsdpReqSocket6 != INVALID_SOCKET) {
-        setsockopt(gSsdpReqSocket6, IPPROTO_IPV6, IPV6_MULTICAST_IF, (char *)&gIF_INDEX, sizeof(gIF_INDEX));
-        fds[nfds].fd = gSsdpReqSocket6;
-        fds[nfds].events = POLLOUT;
-        nfds++;
-    }
-#endif
-    ret = poll(fds, nfds, -1); // Wait indefinitely for the sockets to become writable
-    if (ret == -1) {
-        strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
-        UpnpPrintf(UPNP_INFO, SSDP, __FILE__, __LINE__, "SSDP_LIB: Error in poll(): %s\n", errorBuffer);
-        UpnpCloseSocket(gSsdpReqSocket4);
-#ifdef UPNP_ENABLE_IPV6
-        UpnpCloseSocket(gSsdpReqSocket6);
-#endif
-        return UPNP_E_INTERNAL_ERROR;
-    }
-#ifdef UPNP_ENABLE_IPV6
-    if (gSsdpReqSocket6 != INVALID_SOCKET && (fds[nfds - 1].revents & POLLOUT)) {
-        for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
-            UpnpPrintf(UPNP_INFO, SSDP, __FILE__, __LINE__, ">>> SSDP SEND M-SEARCH >>>\n%s\n", ReqBufv6UlaGua);
-            sendto(gSsdpReqSocket6, ReqBufv6UlaGua, (int)strlen(ReqBufv6UlaGua), 0, (struct sockaddr *)&__ss_v6, sizeof(struct sockaddr_in6));
-            imillisleep(SSDP_PAUSE);
-        }
-        inet_pton(AF_INET6, SSDP_IPV6_LINKLOCAL, &destAddr6->sin6_addr);
-        for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
-            UpnpPrintf(UPNP_INFO, SSDP, __FILE__, __LINE__, ">>> SSDP SEND M-SEARCH >>>\n%s\n", ReqBufv6);
-            sendto(gSsdpReqSocket6, ReqBufv6, (int)strlen(ReqBufv6), 0, (struct sockaddr *)&__ss_v6, sizeof(struct sockaddr_in6));
-            imillisleep(SSDP_PAUSE);
-        }
-    }
-#endif /* IPv6 */
-    if (gSsdpReqSocket4 != INVALID_SOCKET && (fds[0].revents & POLLOUT)) {
-        for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
-            UpnpPrintf(UPNP_INFO, SSDP, __FILE__, __LINE__, ">>> SSDP SEND M-SEARCH >>>\n%s\n", ReqBufv4);
-            sendto(gSsdpReqSocket4, ReqBufv4, (int)strlen(ReqBufv4), 0, (struct sockaddr *)&__ss_v4, sizeof(struct sockaddr_in));
-            imillisleep(SSDP_PAUSE);
-        }
-    }
-    return 1;
+	if (gSsdpReqSocket4 != INVALID_SOCKET) {
+		setsockopt(gSsdpReqSocket4,
+			IPPROTO_IP,
+			IP_MULTICAST_IF,
+			(char *)&addrv4,
+			sizeof(addrv4));
+		fds[nfds].fd = gSsdpReqSocket4;
+		fds[nfds].events = POLLOUT;
+		nfds++;
+	}
+		#ifdef UPNP_ENABLE_IPV6
+	if (gSsdpReqSocket6 != INVALID_SOCKET) {
+		setsockopt(gSsdpReqSocket6,
+			IPPROTO_IPV6,
+			IPV6_MULTICAST_IF,
+			(char *)&gIF_INDEX,
+			sizeof(gIF_INDEX));
+		fds[nfds].fd = gSsdpReqSocket6;
+		fds[nfds].events = POLLOUT;
+		nfds++;
+	}
+		#endif
+	ret = _poll(fds,
+		nfds,
+		-1); // Wait indefinitely for the sockets to become writable
+	if (ret == -1) {
+		strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
+		UpnpPrintf(UPNP_INFO,
+			SSDP,
+			__FILE__,
+			__LINE__,
+			"SSDP_LIB: Error in _poll(): %s\n",
+			errorBuffer);
+		UpnpCloseSocket(gSsdpReqSocket4);
+		#ifdef UPNP_ENABLE_IPV6
+		UpnpCloseSocket(gSsdpReqSocket6);
+		#endif
+		return UPNP_E_INTERNAL_ERROR;
+	}
+		#ifdef UPNP_ENABLE_IPV6
+	if (gSsdpReqSocket6 != INVALID_SOCKET &&
+		(fds[nfds - 1].revents & POLLOUT)) {
+		for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
+			UpnpPrintf(UPNP_INFO,
+				SSDP,
+				__FILE__,
+				__LINE__,
+				">>> SSDP SEND M-SEARCH >>>\n%s\n",
+				ReqBufv6UlaGua);
+			sendto(gSsdpReqSocket6,
+				ReqBufv6UlaGua,
+				(int)strlen(ReqBufv6UlaGua),
+				0,
+				(struct sockaddr *)&__ss_v6,
+				sizeof(struct sockaddr_in6));
+			imillisleep(SSDP_PAUSE);
+		}
+		inet_pton(AF_INET6, SSDP_IPV6_LINKLOCAL, &destAddr6->sin6_addr);
+		for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
+			UpnpPrintf(UPNP_INFO,
+				SSDP,
+				__FILE__,
+				__LINE__,
+				">>> SSDP SEND M-SEARCH >>>\n%s\n",
+				ReqBufv6);
+			sendto(gSsdpReqSocket6,
+				ReqBufv6,
+				(int)strlen(ReqBufv6),
+				0,
+				(struct sockaddr *)&__ss_v6,
+				sizeof(struct sockaddr_in6));
+			imillisleep(SSDP_PAUSE);
+		}
+	}
+		#endif /* IPv6 */
+	if (gSsdpReqSocket4 != INVALID_SOCKET && (fds[0].revents & POLLOUT)) {
+		for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
+			UpnpPrintf(UPNP_INFO,
+				SSDP,
+				__FILE__,
+				__LINE__,
+				">>> SSDP SEND M-SEARCH >>>\n%s\n",
+				ReqBufv4);
+			sendto(gSsdpReqSocket4,
+				ReqBufv4,
+				(int)strlen(ReqBufv4),
+				0,
+				(struct sockaddr *)&__ss_v4,
+				sizeof(struct sockaddr_in));
+			imillisleep(SSDP_PAUSE);
+		}
+	}
+	return 1;
 }
 	#endif /* EXCLUDE_SSDP */
 #endif	       /* INCLUDE_CLIENT_APIS */

--- a/upnp/src/ssdp/ssdp_ctrlpt.c
+++ b/upnp/src/ssdp/ssdp_ctrlpt.c
@@ -41,16 +41,8 @@
 
 #include "upnputil.h"
 
-#ifdef _WIN32
-	#include <winsock2.h>
-	#include <ws2tcpip.h>
-#else
+#ifndef _WIN32
 	#include <poll.h>
-#endif
-
-#ifdef _WIN32
-	#define _poll(fds, nfds, timeout) WSAPoll(fds, nfds, timeout)
-#else
 	#define _poll(fds, nfds, timeout) poll(fds, nfds, timeout)
 #endif
 
@@ -593,9 +585,13 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 	struct Handle_Info *ctrlpt_info = NULL;
 	enum SsdpSearchType requestType;
 	struct in_addr addrv4;
-	SOCKET max_fd = 0;
 	int retVal;
+		#ifdef _WIN32
+	SOCKET max_fd = 0;
+	fd_set wrSet;
+		#else
 	int numCopies;
+		#endif
 
 	/*ThreadData *ThData; */
 	ThreadPoolJob job;
@@ -671,54 +667,50 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 	newArg->timeoutEventId = *id;
 	ListAddTail(&ctrlpt_info->SsdpSearchList, newArg);
 	HandleUnlock(__FILE__, __LINE__);
-	/* End of lock */
+		/* End of lock */
 
-	struct pollfd fds[2];
-	int nfds = 0;
-
+		#ifdef _WIN32
+	FD_ZERO(&wrSet);
 	if (gSsdpReqSocket4 != INVALID_SOCKET) {
 		setsockopt(gSsdpReqSocket4,
 			IPPROTO_IP,
 			IP_MULTICAST_IF,
 			(char *)&addrv4,
 			sizeof(addrv4));
-		fds[nfds].fd = gSsdpReqSocket4;
-		fds[nfds].events = POLLOUT;
-		nfds++;
+		FD_SET(gSsdpReqSocket4, &wrSet);
+		max_fd = max(max_fd, gSsdpReqSocket4);
 	}
-		#ifdef UPNP_ENABLE_IPV6
+			#ifdef UPNP_ENABLE_IPV6
 	if (gSsdpReqSocket6 != INVALID_SOCKET) {
 		setsockopt(gSsdpReqSocket6,
 			IPPROTO_IPV6,
 			IPV6_MULTICAST_IF,
 			(char *)&gIF_INDEX,
 			sizeof(gIF_INDEX));
-		fds[nfds].fd = gSsdpReqSocket6;
-		fds[nfds].events = POLLOUT;
-		nfds++;
+		FD_SET(gSsdpReqSocket6, &wrSet);
+		max_fd = max(max_fd, gSsdpReqSocket6);
 	}
-		#endif
-	ret = _poll(fds,
-		nfds,
-		-1); // Wait indefinitely for the sockets to become writable
+			#endif
+	ret = select((int)max_fd + 1, NULL, &wrSet, NULL, NULL);
 	if (ret == -1) {
 		strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
 		UpnpPrintf(UPNP_INFO,
 			SSDP,
 			__FILE__,
 			__LINE__,
-			"SSDP_LIB: Error in _poll(): %s\n",
+			"SSDP_LIB: Error in select(): %s\n",
 			errorBuffer);
 		UpnpCloseSocket(gSsdpReqSocket4);
-		#ifdef UPNP_ENABLE_IPV6
+			#ifdef UPNP_ENABLE_IPV6
 		UpnpCloseSocket(gSsdpReqSocket6);
-		#endif
+			#endif
 		return UPNP_E_INTERNAL_ERROR;
 	}
-		#ifdef UPNP_ENABLE_IPV6
+			#ifdef UPNP_ENABLE_IPV6
 	if (gSsdpReqSocket6 != INVALID_SOCKET &&
-		(fds[nfds - 1].revents & POLLOUT)) {
-		for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
+		FD_ISSET(gSsdpReqSocket6, &wrSet)) {
+		int NumCopy = 0;
+		while (NumCopy < NUM_SSDP_COPY) {
 			UpnpPrintf(UPNP_INFO,
 				SSDP,
 				__FILE__,
@@ -732,9 +724,11 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 				(struct sockaddr *)&__ss_v6,
 				sizeof(struct sockaddr_in6));
 			imillisleep(SSDP_PAUSE);
+			NumCopy++;
 		}
+		NumCopy = 0;
 		inet_pton(AF_INET6, SSDP_IPV6_LINKLOCAL, &destAddr6->sin6_addr);
-		for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
+		while (NumCopy < NUM_SSDP_COPY) {
 			UpnpPrintf(UPNP_INFO,
 				SSDP,
 				__FILE__,
@@ -748,11 +742,14 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 				(struct sockaddr *)&__ss_v6,
 				sizeof(struct sockaddr_in6));
 			imillisleep(SSDP_PAUSE);
+			NumCopy++;
 		}
 	}
-		#endif /* IPv6 */
-	if (gSsdpReqSocket4 != INVALID_SOCKET && (fds[0].revents & POLLOUT)) {
-		for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
+			#endif /* IPv6 */
+	if (gSsdpReqSocket4 != INVALID_SOCKET &&
+		FD_ISSET(gSsdpReqSocket4, &wrSet)) {
+		int NumCopy = 0;
+		while (NumCopy < NUM_SSDP_COPY) {
 			UpnpPrintf(UPNP_INFO,
 				SSDP,
 				__FILE__,
@@ -766,8 +763,112 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 				(struct sockaddr *)&__ss_v4,
 				sizeof(struct sockaddr_in));
 			imillisleep(SSDP_PAUSE);
+			NumCopy++;
 		}
 	}
+		#else /* _WIN32 */
+	{
+		struct pollfd fds[2];
+		int nfds = 0;
+
+		if (gSsdpReqSocket4 != INVALID_SOCKET) {
+			setsockopt(gSsdpReqSocket4,
+				IPPROTO_IP,
+				IP_MULTICAST_IF,
+				(char *)&addrv4,
+				sizeof(addrv4));
+			fds[nfds].fd = gSsdpReqSocket4;
+			fds[nfds].events = POLLOUT;
+			nfds++;
+		}
+			#ifdef UPNP_ENABLE_IPV6
+		if (gSsdpReqSocket6 != INVALID_SOCKET) {
+			setsockopt(gSsdpReqSocket6,
+				IPPROTO_IPV6,
+				IPV6_MULTICAST_IF,
+				(char *)&gIF_INDEX,
+				sizeof(gIF_INDEX));
+			fds[nfds].fd = gSsdpReqSocket6;
+			fds[nfds].events = POLLOUT;
+			nfds++;
+		}
+			#endif
+		ret = _poll(fds, nfds, -1);
+		if (ret == -1) {
+			strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
+			UpnpPrintf(UPNP_INFO,
+				SSDP,
+				__FILE__,
+				__LINE__,
+				"SSDP_LIB: Error in _poll(): %s\n",
+				errorBuffer);
+			UpnpCloseSocket(gSsdpReqSocket4);
+			#ifdef UPNP_ENABLE_IPV6
+			UpnpCloseSocket(gSsdpReqSocket6);
+			#endif
+			return UPNP_E_INTERNAL_ERROR;
+		}
+			#ifdef UPNP_ENABLE_IPV6
+		if (gSsdpReqSocket6 != INVALID_SOCKET &&
+			(fds[nfds - 1].revents & POLLOUT)) {
+			for (numCopies = 0; numCopies < NUM_SSDP_COPY;
+				numCopies++) {
+				UpnpPrintf(UPNP_INFO,
+					SSDP,
+					__FILE__,
+					__LINE__,
+					">>> SSDP SEND M-SEARCH >>>\n%s\n",
+					ReqBufv6UlaGua);
+				sendto(gSsdpReqSocket6,
+					ReqBufv6UlaGua,
+					(int)strlen(ReqBufv6UlaGua),
+					0,
+					(struct sockaddr *)&__ss_v6,
+					sizeof(struct sockaddr_in6));
+				imillisleep(SSDP_PAUSE);
+			}
+			inet_pton(AF_INET6,
+				SSDP_IPV6_LINKLOCAL,
+				&destAddr6->sin6_addr);
+			for (numCopies = 0; numCopies < NUM_SSDP_COPY;
+				numCopies++) {
+				UpnpPrintf(UPNP_INFO,
+					SSDP,
+					__FILE__,
+					__LINE__,
+					">>> SSDP SEND M-SEARCH >>>\n%s\n",
+					ReqBufv6);
+				sendto(gSsdpReqSocket6,
+					ReqBufv6,
+					(int)strlen(ReqBufv6),
+					0,
+					(struct sockaddr *)&__ss_v6,
+					sizeof(struct sockaddr_in6));
+				imillisleep(SSDP_PAUSE);
+			}
+		}
+			#endif /* IPv6 */
+		if (gSsdpReqSocket4 != INVALID_SOCKET &&
+			(fds[0].revents & POLLOUT)) {
+			for (numCopies = 0; numCopies < NUM_SSDP_COPY;
+				numCopies++) {
+				UpnpPrintf(UPNP_INFO,
+					SSDP,
+					__FILE__,
+					__LINE__,
+					">>> SSDP SEND M-SEARCH >>>\n%s\n",
+					ReqBufv4);
+				sendto(gSsdpReqSocket4,
+					ReqBufv4,
+					(int)strlen(ReqBufv4),
+					0,
+					(struct sockaddr *)&__ss_v4,
+					sizeof(struct sockaddr_in));
+				imillisleep(SSDP_PAUSE);
+			}
+		}
+	}
+		#endif	       /* _WIN32 */
 	return 1;
 }
 	#endif /* EXCLUDE_SSDP */

--- a/upnp/src/ssdp/ssdp_ctrlpt.c
+++ b/upnp/src/ssdp/ssdp_ctrlpt.c
@@ -40,6 +40,7 @@
 #include "config.h"
 
 #include "upnputil.h"
+#include <poll.h>
 
 #ifdef INCLUDE_CLIENT_APIS
 	#if EXCLUDE_SSDP == 0
@@ -574,7 +575,6 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 		#ifdef UPNP_ENABLE_IPV6
 	struct sockaddr_in6 *destAddr6 = (struct sockaddr_in6 *)&__ss_v6;
 		#endif
-	fd_set wrSet;
 	SsdpSearchArg *newArg = NULL;
 	SsdpSearchExpArg *expArg = NULL;
 	int timeTillRead = 0;
@@ -583,6 +583,7 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 	struct in_addr addrv4;
 	SOCKET max_fd = 0;
 	int retVal;
+	int numCopies;
 
 	/*ThreadData *ThData; */
 	ThreadPoolJob job;
@@ -660,105 +661,56 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 	HandleUnlock(__FILE__, __LINE__);
 	/* End of lock */
 
-	FD_ZERO(&wrSet);
-	if (gSsdpReqSocket4 != INVALID_SOCKET) {
-		setsockopt(gSsdpReqSocket4,
-			IPPROTO_IP,
-			IP_MULTICAST_IF,
-			(char *)&addrv4,
-			sizeof(addrv4));
-		FD_SET(gSsdpReqSocket4, &wrSet);
-		max_fd = max(max_fd, gSsdpReqSocket4);
-	}
-		#ifdef UPNP_ENABLE_IPV6
-	if (gSsdpReqSocket6 != INVALID_SOCKET) {
-		setsockopt(gSsdpReqSocket6,
-			IPPROTO_IPV6,
-			IPV6_MULTICAST_IF,
-			(char *)&gIF_INDEX,
-			sizeof(gIF_INDEX));
-		FD_SET(gSsdpReqSocket6, &wrSet);
-		max_fd = max(max_fd, gSsdpReqSocket6);
-	}
-		#endif
-	ret = select((int)max_fd + 1, NULL, &wrSet, NULL, NULL);
-	if (ret == -1) {
-		strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
-		UpnpPrintf(UPNP_INFO,
-			SSDP,
-			__FILE__,
-			__LINE__,
-			"SSDP_LIB: Error in select(): %s\n",
-			errorBuffer);
-		UpnpCloseSocket(gSsdpReqSocket4);
-		#ifdef UPNP_ENABLE_IPV6
-		UpnpCloseSocket(gSsdpReqSocket6);
-		#endif
-		return UPNP_E_INTERNAL_ERROR;
-	}
-		#ifdef UPNP_ENABLE_IPV6
-	if (gSsdpReqSocket6 != INVALID_SOCKET &&
-		FD_ISSET(gSsdpReqSocket6, &wrSet)) {
-		int NumCopy = 0;
+	struct pollfd fds[2];
+    int nfds = 0;
 
-		while (NumCopy < NUM_SSDP_COPY) {
-			UpnpPrintf(UPNP_INFO,
-				SSDP,
-				__FILE__,
-				__LINE__,
-				">>> SSDP SEND M-SEARCH >>>\n%s\n",
-				ReqBufv6UlaGua);
-			sendto(gSsdpReqSocket6,
-				ReqBufv6UlaGua,
-				strlen(ReqBufv6UlaGua),
-				0,
-				(struct sockaddr *)&__ss_v6,
-				sizeof(struct sockaddr_in6));
-			NumCopy++;
-			imillisleep(SSDP_PAUSE);
-		}
-		NumCopy = 0;
-		inet_pton(AF_INET6, SSDP_IPV6_LINKLOCAL, &destAddr6->sin6_addr);
-		while (NumCopy < NUM_SSDP_COPY) {
-			UpnpPrintf(UPNP_INFO,
-				SSDP,
-				__FILE__,
-				__LINE__,
-				">>> SSDP SEND M-SEARCH >>>\n%s\n",
-				ReqBufv6);
-			sendto(gSsdpReqSocket6,
-				ReqBufv6,
-				strlen(ReqBufv6),
-				0,
-				(struct sockaddr *)&__ss_v6,
-				sizeof(struct sockaddr_in6));
-			NumCopy++;
-			imillisleep(SSDP_PAUSE);
-		}
-	}
-		#endif /* IPv6 */
-	if (gSsdpReqSocket4 != INVALID_SOCKET &&
-		FD_ISSET(gSsdpReqSocket4, &wrSet)) {
-		int NumCopy = 0;
-		while (NumCopy < NUM_SSDP_COPY) {
-			UpnpPrintf(UPNP_INFO,
-				SSDP,
-				__FILE__,
-				__LINE__,
-				">>> SSDP SEND M-SEARCH >>>\n%s\n",
-				ReqBufv4);
-			sendto(gSsdpReqSocket4,
-				ReqBufv4,
-				strlen(ReqBufv4),
-				0,
-				(struct sockaddr *)&__ss_v4,
-				sizeof(struct sockaddr_in));
-			NumCopy++;
-			imillisleep(SSDP_PAUSE);
-		}
-	}
-
-	return 1;
+    if (gSsdpReqSocket4 != INVALID_SOCKET) {
+        setsockopt(gSsdpReqSocket4, IPPROTO_IP, IP_MULTICAST_IF, (char *)&addrv4, sizeof(addrv4));
+        fds[nfds].fd = gSsdpReqSocket4;
+        fds[nfds].events = POLLOUT;
+        nfds++;
+    }
+#ifdef UPNP_ENABLE_IPV6
+    if (gSsdpReqSocket6 != INVALID_SOCKET) {
+        setsockopt(gSsdpReqSocket6, IPPROTO_IPV6, IPV6_MULTICAST_IF, (char *)&gIF_INDEX, sizeof(gIF_INDEX));
+        fds[nfds].fd = gSsdpReqSocket6;
+        fds[nfds].events = POLLOUT;
+        nfds++;
+    }
+#endif
+    ret = poll(fds, nfds, -1); // Wait indefinitely for the sockets to become writable
+    if (ret == -1) {
+        strerror_r(errno, errorBuffer, ERROR_BUFFER_LEN);
+        UpnpPrintf(UPNP_INFO, SSDP, __FILE__, __LINE__, "SSDP_LIB: Error in poll(): %s\n", errorBuffer);
+        UpnpCloseSocket(gSsdpReqSocket4);
+#ifdef UPNP_ENABLE_IPV6
+        UpnpCloseSocket(gSsdpReqSocket6);
+#endif
+        return UPNP_E_INTERNAL_ERROR;
+    }
+#ifdef UPNP_ENABLE_IPV6
+    if (gSsdpReqSocket6 != INVALID_SOCKET && (fds[nfds - 1].revents & POLLOUT)) {
+        for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
+            UpnpPrintf(UPNP_INFO, SSDP, __FILE__, __LINE__, ">>> SSDP SEND M-SEARCH >>>\n%s\n", ReqBufv6UlaGua);
+            sendto(gSsdpReqSocket6, ReqBufv6UlaGua, (int)strlen(ReqBufv6UlaGua), 0, (struct sockaddr *)&__ss_v6, sizeof(struct sockaddr_in6));
+            imillisleep(SSDP_PAUSE);
+        }
+        inet_pton(AF_INET6, SSDP_IPV6_LINKLOCAL, &destAddr6->sin6_addr);
+        for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
+            UpnpPrintf(UPNP_INFO, SSDP, __FILE__, __LINE__, ">>> SSDP SEND M-SEARCH >>>\n%s\n", ReqBufv6);
+            sendto(gSsdpReqSocket6, ReqBufv6, (int)strlen(ReqBufv6), 0, (struct sockaddr *)&__ss_v6, sizeof(struct sockaddr_in6));
+            imillisleep(SSDP_PAUSE);
+        }
+    }
+#endif /* IPv6 */
+    if (gSsdpReqSocket4 != INVALID_SOCKET && (fds[0].revents & POLLOUT)) {
+        for (numCopies = 0; numCopies < NUM_SSDP_COPY; numCopies++) {
+            UpnpPrintf(UPNP_INFO, SSDP, __FILE__, __LINE__, ">>> SSDP SEND M-SEARCH >>>\n%s\n", ReqBufv4);
+            sendto(gSsdpReqSocket4, ReqBufv4, (int)strlen(ReqBufv4), 0, (struct sockaddr *)&__ss_v4, sizeof(struct sockaddr_in));
+            imillisleep(SSDP_PAUSE);
+        }
+    }
+    return 1;
 }
 	#endif /* EXCLUDE_SSDP */
 #endif	       /* INCLUDE_CLIENT_APIS */

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -2,6 +2,7 @@ UPNP_Add_Unit_Test(test-upnp-list test_list.c)
 UPNP_Add_Unit_Test(test-upnp-init test_init.c)
 UPNP_Add_Unit_Test(test-upnp-log test_log.c)
 UPNP_Add_Unit_Test(test-upnp-url test_url.c)
+UPNP_Add_Unit_Test(test-upnp-sock-io test_sock_io.c)
 # test_threadpool_overflow calls internal ThreadPool API (ThreadPoolInit,
 # TPAttrInit, …) that have hidden visibility in the shared library.  Compile
 # the three ThreadPool translation units directly into each test variant so

--- a/upnp/test/test_sock_io.c
+++ b/upnp/test/test_sock_io.c
@@ -1,0 +1,120 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*- */
+/**************************************************************************
+ *
+ * Copyright (c) 2026 The pupnp contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************/
+
+/*!
+ * \file
+ * \brief Regression test for PR #519 (poll() vs select() socket readiness).
+ *
+ * On Windows x64 with MinGW, WSAPoll() expects WSAPOLLFD (SOCKET fd, 64-bit)
+ * but struct pollfd has an int fd (32-bit), causing UpnpInit2() to hang.
+ * This test verifies that:
+ *   1. UpnpInit2() / UpnpFinish() complete within the test timeout.
+ *   2. UpnpSearchAsync() completes without hanging, exercising the
+ *      poll() (non-Windows) / select() (Windows) path in SearchByTarget().
+ */
+
+#include "upnp.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "ithread.h" /* for imillisleep */
+
+#include "posix_overwrites.h" /* IWYU pragma: keep */
+
+static int discovery_callback(
+	Upnp_EventType event_type, void *event, void *cookie)
+{
+	(void)event_type;
+	(void)event;
+	(void)cookie;
+	return 0;
+}
+
+int main(void)
+{
+	int rc;
+	UpnpClient_Handle handle = -1;
+
+	/*
+	 * Step 1: UpnpInit2() starts the miniserver thread, which calls
+	 * RunMiniServer().  On Windows this used to hang because WSAPoll()
+	 * was called with struct pollfd (int fd) instead of WSAPOLLFD
+	 * (SOCKET fd).  With the fix, select() is used on Windows.
+	 */
+	printf("Initializing UPnP stack ... ");
+	fflush(stdout);
+	rc = UpnpInit2(NULL, 0);
+	if (rc != UPNP_E_SUCCESS) {
+		printf("FAIL (UpnpInit2 returned %d)\n", rc);
+		exit(EXIT_FAILURE);
+	}
+	printf("OK\n");
+
+	/*
+	 * Step 2: Register as a control point client so we can issue
+	 * a discovery search.
+	 */
+	printf("Registering control point ... ");
+	fflush(stdout);
+	rc = UpnpRegisterClient(discovery_callback, NULL, &handle);
+	if (rc != UPNP_E_SUCCESS) {
+		printf("FAIL (UpnpRegisterClient returned %d)\n", rc);
+		UpnpFinish();
+		exit(EXIT_FAILURE);
+	}
+	printf("OK\n");
+
+	/*
+	 * Step 3: Issue an SSDP M-SEARCH.  SearchByTarget() uses
+	 * poll() (non-Windows) or select() (Windows) to wait until the
+	 * multicast socket is writable before sending.  With the old broken
+	 * WSAPoll() path this call could hang or return an error.
+	 * Mx=1 means the search expires after 1 second.
+	 */
+	printf("Sending SSDP search (Mx=1s) ... ");
+	fflush(stdout);
+	rc = UpnpSearchAsync(handle, 1, "ssdp:all", NULL);
+	if (rc != UPNP_E_SUCCESS) {
+		printf("FAIL (UpnpSearchAsync returned %d)\n", rc);
+		UpnpUnRegisterClient(handle);
+		UpnpFinish();
+		exit(EXIT_FAILURE);
+	}
+	printf("OK\n");
+
+	/* Wait for the search Mx timer to expire. */
+	imillisleep(1500);
+
+	UpnpUnRegisterClient(handle);
+	UpnpFinish();
+
+	printf("test_sock_io: PASS\n");
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
## Summary

This supersedes PR #519 ("Adapt genlib and ssdp to use poll() instead of select()") and fixes the Windows hang it introduced.

- Rebased the original 4 commits from #519 onto current `main`
- Added a fifth commit that restores `select()` on Windows and keeps `poll()` only on non-Windows platforms
- Added a regression test (`test-upnp-sock-io`) that exercises `UpnpInit2()` and `UpnpSearchAsync()` to catch future regressions on either platform

## Why the original PR hung on Windows

`WSAPoll()` (used via the `_poll` macro) expects `WSAPOLLFD` whose `fd` field is `SOCKET` (a 64-bit handle on x64). MinGW's POSIX-layer `struct pollfd` has `int fd` (32-bit). Passing `struct pollfd` to `WSAPoll` causes it to read garbage in the file-descriptor field, so it never reports the socket as ready — hanging `UpnpInit2()` indefinitely.

## What changed

| File | Change |
|------|--------|
| `upnp/src/genlib/net/sock.c` | `#ifndef _WIN32` poll path; Windows keeps `select()` |
| `upnp/src/genlib/net/http/httpreadwrite.c` | Same pattern; `Check_Connect_And_Wait_Connection()` uses `select()` on both platforms |
| `upnp/src/ssdp/ssdp_ctrlpt.c` | `SearchByTarget()`: `select()` + `FD_ISSET` on Windows; `poll()` + `revents` on non-Windows |
| `upnp/src/genlib/miniserver/miniserver.c` | `RunMiniServer()`: `select()` loop on Windows; `poll()` loop on non-Windows |
| `upnp/test/test_sock_io.c` | New regression test |

## Test plan

- [x] Linux CI passes (poll() path)
- [x] Windows CI passes — `test-upnp-init` and `test-upnp-sock-io` complete within timeout (no hang)
- [x] macOS / other POSIX CI passes

Closes #519