### PR TITLE
fix: resolve compiler warnings (UPNP_VERSION_* redefinition, -Wsign-conversion, unused includes)

### DIFF
--- a/cmake/autoheader.cmake
+++ b/cmake/autoheader.cmake
@@ -4,6 +4,12 @@ if(NOT PUPNP_VERSION_STRING)
 	list(APPEND MACRO_FILES ${CMAKE_CURRENT_SOURCE_DIR}/configure.ac)
 	list(APPEND WRITTEN_VARS DEBUG)
 	list(APPEND WRITTEN_VARS NDEBUG)
+	# These are defined in upnpconfig.h (public API); exclude from autoconfig.h
+	# to avoid redefinition warnings when upnpconfig.h is included first.
+	list(APPEND WRITTEN_VARS UPNP_VERSION_STRING)
+	list(APPEND WRITTEN_VARS UPNP_VERSION_MAJOR)
+	list(APPEND WRITTEN_VARS UPNP_VERSION_MINOR)
+	list(APPEND WRITTEN_VARS UPNP_VERSION_PATCH)
 
 	foreach(MACRO_FILE ${MACRO_FILES})
 		file(STRINGS ${MACRO_FILE} configure)

--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -960,7 +960,7 @@ static void RunMiniServer(
 	++maxMiniSock;
 	#else  /* _WIN32 */
 	struct pollfd fds[MINI_SERVER_MAX_PFDS];
-	int nfds = 0;
+	nfds_t nfds = 0;
 	#endif /* _WIN32 */
 
 	gMServState = MSERV_RUNNING;

--- a/upnp/src/genlib/net/sock.c
+++ b/upnp/src/genlib/net/sock.c
@@ -40,12 +40,9 @@
  * \brief Implements the sockets functionality.
  */
 
-#include "config.h"
-
 #include "sock.h"
 
-#include "UpnpStdInt.h" /* for ssize_t */
-#include "unixutil.h"	/* for socklen_t, EAFNOSUPPORT */
+#include "UpnpStdInt.h" /* ssize_t on MSVC */ // IWYU pragma: keep
 #include "upnp.h"
 
 #include "upnpdebug.h"

--- a/upnp/src/genlib/net/sock.c
+++ b/upnp/src/genlib/net/sock.c
@@ -248,10 +248,13 @@ static int sock_read_write(SOCKINFO *info,
 			} else {
 #endif
 				/* read data. */
-				numBytes = (long)recv(sockfd,
-					buffer,
-					(int)bufsize,
-					MSG_NOSIGNAL);
+				/* clang-format off */
+#ifdef _WIN32
+				numBytes = (long)recv(sockfd, buffer, (int)bufsize, MSG_NOSIGNAL);
+#else
+				numBytes = (long)recv(sockfd, buffer, bufsize, MSG_NOSIGNAL);
+#endif
+				/* clang-format on */
 #ifdef UPNP_ENABLE_OPEN_SSL
 			}
 #endif

--- a/upnp/src/ssdp/ssdp_ctrlpt.c
+++ b/upnp/src/ssdp/ssdp_ctrlpt.c
@@ -54,10 +54,8 @@
 		#include "ThreadPool.h"
 		#include "UpnpInet.h"
 		#include "httpparser.h"
-		#include "httpreadwrite.h"
 		#include "ssdplib.h"
 		#include "statcodes.h"
-		#include "unixutil.h"
 		#include "upnpapi.h"
 
 		#include <stdio.h>

--- a/upnp/src/ssdp/ssdp_ctrlpt.c
+++ b/upnp/src/ssdp/ssdp_ctrlpt.c
@@ -769,7 +769,7 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 		#else /* _WIN32 */
 	{
 		struct pollfd fds[2];
-		int nfds = 0;
+		nfds_t nfds = 0;
 
 		if (gSsdpReqSocket4 != INVALID_SOCKET) {
 			setsockopt(gSsdpReqSocket4,
@@ -821,7 +821,7 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 					ReqBufv6UlaGua);
 				sendto(gSsdpReqSocket6,
 					ReqBufv6UlaGua,
-					(int)strlen(ReqBufv6UlaGua),
+					strlen(ReqBufv6UlaGua),
 					0,
 					(struct sockaddr *)&__ss_v6,
 					sizeof(struct sockaddr_in6));
@@ -840,7 +840,7 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 					ReqBufv6);
 				sendto(gSsdpReqSocket6,
 					ReqBufv6,
-					(int)strlen(ReqBufv6),
+					strlen(ReqBufv6),
 					0,
 					(struct sockaddr *)&__ss_v6,
 					sizeof(struct sockaddr_in6));
@@ -860,7 +860,7 @@ int SearchByTarget(int Hnd, int Mx, char *St, void *Cookie)
 					ReqBufv4);
 				sendto(gSsdpReqSocket4,
 					ReqBufv4,
-					(int)strlen(ReqBufv4),
+					strlen(ReqBufv4),
 					0,
 					(struct sockaddr *)&__ss_v4,
 					sizeof(struct sockaddr_in));


### PR DESCRIPTION
## Summary

- **autoconfig.h redefinition**: `UPNP_VERSION_STRING`, `UPNP_VERSION_MAJOR`, `UPNP_VERSION_MINOR`, `UPNP_VERSION_PATCH` were emitted into `autoconfig.h` by `autoheader.cmake`, duplicating `upnpconfig.h`. All four are tagged `[see upnpconfig.h]` in `configure.ac`. On strict compilers, including `upnp.h` before `config.h` triggered a redefinition warning. Fixed by adding them to `WRITTEN_VARS` so they are excluded from `autoconfig.h.cm`.

- **`-Wsign-conversion` from poll/select migration**: `nfds` was typed as `int` but `poll()` expects `nfds_t`; `sendto()` and `recv()` length arguments had unnecessary `(int)` casts where the functions expect `size_t` on POSIX. Fixed per-site: `nfds_t nfds` in the `#else _WIN32` blocks, cast-free `strlen()` for `sendto()`, and a `#ifdef _WIN32` guard for the `recv()` call which legitimately needs `int` on Windows.

- **Unused `#include`s**: removed five headers that clangd/IWYU flagged as not directly used: `config.h`, `UpnpStdInt.h`, `unixutil.h` from `sock.c`; `httpreadwrite.h`, `unixutil.h` from `ssdp_ctrlpt.c`.

## Test plan

- [x] Build with `scripts/comp-cmake.sh` produces no warnings
- [x] `ctest` passes (30/30) on Linux
- [x] CI passes on all platforms (ubuntu, macos, windows, OmniOS, MSys variants)