### PR TITLE
fix: replace select()/FD_SET() with poll() in Check_Connect_And_Wait_Connection

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -28,8 +28,7 @@ env:
     -DBUILD_TESTING=ON \
     -DDOWNLOAD_AND_BUILD_DEPS=ON \
     -DUPNP_ENABLE_OPEN_SSL=ON \
-    -DUPNP_ENABLE_UNSPECIFIED_SERVER=ON \
-    -DUPNP_ENABLE_BLOCKING_TCP_CONNECTIONS=ON
+    -DUPNP_ENABLE_UNSPECIFIED_SERVER=ON
 
   cmake_sanitizer_flags: |-
     -DCMAKE_C_FLAGS="-fsanitize=address,leak" \
@@ -50,6 +49,14 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         conf: [ Debug, Release ]
+        include:
+          # Debug builds enable _FORTIFY_SOURCE=2 to catch buffer-overflow
+          # bugs such as FD_SET with fd >= FD_SETSIZE (issue #423).
+          # -O1 is required: _FORTIFY_SOURCE is a no-op at -O0.
+          - conf: Debug
+            extra_c_flags: " -O1 -D_FORTIFY_SOURCE=2"
+          - conf: Release
+            extra_c_flags: ""
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
@@ -57,7 +64,7 @@ jobs:
         run: |
           cmake \
             ${{ env.cmake_common_flags }} \
-            -DCMAKE_C_FLAGS="-Wall -Wpedantic" \
+            -DCMAKE_C_FLAGS="-Wall -Wpedantic${{ matrix.extra_c_flags }}" \
             -DCMAKE_BUILD_TYPE=${{ matrix.conf }} \
             -DCMAKE_INSTALL_PREFIX=${{ GITHUB.WORKSPACE }}/test-install
       - name: Build

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -104,22 +104,15 @@ const int CHUNK_TAIL_SIZE = 10;
  */
 static int Check_Connect_And_Wait_Connection(SOCKET sock, int connect_res)
 {
-	struct timeval tmvTimeout = {DEFAULT_TCP_CONNECT_TIMEOUT, 0};
 	int result;
-	#ifdef _WIN32
-	struct fd_set fdSet;
-	#else
-	fd_set fdSet;
-	#endif
-	FD_ZERO(&fdSet);
-	FD_SET(sock, &fdSet);
 
 	if (connect_res < 0) {
 	#ifdef _WIN32
+		struct fd_set fdSet;
+		struct timeval tmvTimeout = {DEFAULT_TCP_CONNECT_TIMEOUT, 0};
+		FD_ZERO(&fdSet);
+		FD_SET(sock, &fdSet);
 		if (WSAEWOULDBLOCK == WSAGetLastError()) {
-	#else
-		if (EINPROGRESS == errno) {
-	#endif
 			result = select(
 				(int)sock + 1, NULL, &fdSet, NULL, &tmvTimeout);
 			if (result < 0) {
@@ -127,7 +120,23 @@ static int Check_Connect_And_Wait_Connection(SOCKET sock, int connect_res)
 			} else if (result == 0) {
 				/* timeout */
 				return -1;
-	#ifndef _WIN32
+			}
+		}
+	#else
+		/* Use poll() instead of select()/FD_SET() to avoid the
+		 * FD_SETSIZE (1024) limit: FD_SET with fd >= FD_SETSIZE
+		 * overflows the bitmap. */
+		if (EINPROGRESS == errno) {
+			struct pollfd pfd;
+			pfd.fd = (int)sock;
+			pfd.events = POLLOUT;
+			result = _poll(
+				&pfd, 1, DEFAULT_TCP_CONNECT_TIMEOUT * 1000);
+			if (result < 0) {
+				return -1;
+			} else if (result == 0) {
+				/* timeout */
+				return -1;
 			} else {
 				int valopt = 0;
 				socklen_t len = sizeof(valopt);
@@ -142,9 +151,9 @@ static int Check_Connect_And_Wait_Connection(SOCKET sock, int connect_res)
 					/* delayed error = valopt */
 					return -1;
 				}
-	#endif
 			}
 		}
+	#endif
 	}
 
 	return 0;

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -118,6 +118,24 @@ if(UPNP_BUILD_STATIC)
 	)
 endif()
 
+# Issue #423: crash when socket fd >= FD_SETSIZE due to FD_SET overflow in
+# Check_Connect_And_Wait_Connection().  The fix uses poll() on non-Windows.
+UPNP_Add_Unit_Test(test-upnp-connect-high-fd test_connect_high_fd.c)
+if(UPNP_BUILD_SHARED)
+	target_link_libraries(test-upnp-connect-high-fd PRIVATE
+		Threads::Threads
+		$<$<BOOL:${SOCKET_LIBRARY}>:${SOCKET_LIBRARY}>
+		$<$<BOOL:${NSL_LIBRARY}>:${NSL_LIBRARY}>
+	)
+endif()
+if(UPNP_BUILD_STATIC)
+	target_link_libraries(test-upnp-connect-high-fd-static PRIVATE
+		Threads::Threads
+		$<$<BOOL:${SOCKET_LIBRARY}>:${SOCKET_LIBRARY}>
+		$<$<BOOL:${NSL_LIBRARY}>:${NSL_LIBRARY}>
+	)
+endif()
+
 if(UPNP_BUILD_SHARED)
 	add_executable(
 		test-upnp-parse-uri

--- a/upnp/test/test_connect_high_fd.c
+++ b/upnp/test/test_connect_high_fd.c
@@ -1,0 +1,293 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*- */
+/**************************************************************************
+ *
+ * Copyright (c) 2026 The pupnp contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************/
+
+/*!
+ * \file
+ * \brief Regression test for issue #423 (crash when socket fd >= FD_SETSIZE).
+ *
+ * Root cause: Check_Connect_And_Wait_Connection() in httpreadwrite.c called
+ * FD_SET(sock, &fdSet) unconditionally.  When sock >= FD_SETSIZE (1024),
+ * glibc's _FORTIFY_SOURCE turns FD_SET into __fdelt_chk() which abort()s.
+ * Without _FORTIFY_SOURCE the fd_set bitmap is silently overflowed,
+ * corrupting adjacent stack memory.
+ *
+ * Fix: replace select()/FD_SET() with poll() on non-Windows.  poll() uses
+ * an array of struct pollfd and has no fd-number limit.
+ *
+ * Test:
+ *   1. Raise RLIMIT_NOFILE above FD_SETSIZE and open dummy fds so the next
+ *      socket() call returns fd >= FD_SETSIZE.
+ *   2. Spin up a minimal HTTP/1.1 server on 127.0.0.1 in a background thread.
+ *   3. Call UpnpDownloadXmlDoc() which calls http_RequestAndResponse() ->
+ *      private_connect() -> Check_Connect_And_Wait_Connection().
+ *      Old code: FD_SET(sock >= FD_SETSIZE) -> abort().
+ *      Fixed code: poll() -> no limit, completes normally.
+ */
+
+#include "posix_overwrites.h" /* IWYU pragma: keep */
+#include "upnp.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _WIN32
+
+	#include <arpa/inet.h>
+	#include <fcntl.h>
+	#include <netinet/in.h>
+	#include <pthread.h>
+	#include <sys/resource.h>
+	#include <sys/socket.h>
+	#include <sys/time.h>
+	#include <unistd.h>
+
+/* Minimal valid UPnP device description. */
+static const char XML_BODY[] =
+	"<?xml version=\"1.0\"?>"
+	"<root xmlns=\"urn:schemas-upnp-org:device-1-0\">"
+	"<specVersion><major>1</major><minor>0</minor></specVersion>"
+	"<device>"
+	"<deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType>"
+	"<friendlyName>test423</friendlyName>"
+	"<manufacturer>Test</manufacturer>"
+	"<modelName>Test</modelName>"
+	"<UDN>uuid:test423-0000-0000-0000-000000000000</UDN>"
+	"</device>"
+	"</root>";
+
+struct server_state
+{
+	int listenfd;
+	unsigned short port;
+};
+
+static void *http_server_thread(void *arg)
+{
+	struct server_state *srv = (struct server_state *)arg;
+	char req_buf[2048];
+	char resp_buf[1024];
+	int resp_len;
+	int cfd;
+	struct timeval tv;
+
+	tv.tv_sec = 10;
+	tv.tv_usec = 0;
+
+	cfd = accept(srv->listenfd, NULL, NULL);
+	if (cfd < 0)
+		return NULL;
+
+	setsockopt(cfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+	setsockopt(cfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+	recv(cfd, req_buf, sizeof(req_buf) - 1, 0);
+
+	resp_len = snprintf(resp_buf,
+		sizeof(resp_buf),
+		"HTTP/1.1 200 OK\r\n"
+		"Content-Type: text/xml\r\n"
+		"Content-Length: %zu\r\n"
+		"Connection: close\r\n"
+		"\r\n"
+		"%s",
+		strlen(XML_BODY),
+		XML_BODY);
+
+	send(cfd, resp_buf, (size_t)resp_len, 0);
+	close(cfd);
+	return NULL;
+}
+
+static int setup_server(struct server_state *srv)
+{
+	struct sockaddr_in addr;
+	socklen_t alen = sizeof(addr);
+	struct timeval tv;
+	int one = 1;
+
+	tv.tv_sec = 10;
+	tv.tv_usec = 0;
+
+	srv->listenfd = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv->listenfd < 0) {
+		perror("socket");
+		return -1;
+	}
+	setsockopt(srv->listenfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+	setsockopt(srv->listenfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	addr.sin_port = 0;
+
+	if (bind(srv->listenfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		perror("bind");
+		close(srv->listenfd);
+		return -1;
+	}
+	if (listen(srv->listenfd, 4) < 0) {
+		perror("listen");
+		close(srv->listenfd);
+		return -1;
+	}
+	if (getsockname(srv->listenfd, (struct sockaddr *)&addr, &alen) < 0) {
+		perror("getsockname");
+		close(srv->listenfd);
+		return -1;
+	}
+	srv->port = ntohs(addr.sin_port);
+	return 0;
+}
+
+int main(void)
+{
+	struct server_state srv;
+	pthread_t srv_tid;
+	struct rlimit rl;
+	int *dummy_fds;
+	int n_dummy = 0;
+	char url[80];
+	IXML_Document *doc = NULL;
+	int rc;
+
+	/* Step 1: set up listening server before opening dummy fds so it gets
+	 * a small fd number. */
+	if (setup_server(&srv) < 0)
+		return EXIT_FAILURE;
+	printf("HTTP server on 127.0.0.1:%u (listenfd=%d)\n",
+		(unsigned)srv.port,
+		srv.listenfd);
+
+	/* Step 2: raise RLIMIT_NOFILE so we can open fds above FD_SETSIZE. */
+	if (getrlimit(RLIMIT_NOFILE, &rl) < 0) {
+		perror("getrlimit");
+		close(srv.listenfd);
+		return EXIT_FAILURE;
+	}
+	if (rl.rlim_cur < (rlim_t)(FD_SETSIZE + 64)) {
+		rl.rlim_cur = (rlim_t)(FD_SETSIZE + 64);
+		if (rl.rlim_cur > rl.rlim_max)
+			rl.rlim_cur = rl.rlim_max;
+		setrlimit(RLIMIT_NOFILE, &rl); /* best-effort */
+	}
+
+	/* Step 3: open dummy fds until the highest open fd >= FD_SETSIZE - 1,
+	 * which ensures the next socket() call returns fd >= FD_SETSIZE. */
+	dummy_fds = malloc((size_t)(FD_SETSIZE + 64) * sizeof(int));
+	if (!dummy_fds) {
+		perror("malloc");
+		close(srv.listenfd);
+		return EXIT_FAILURE;
+	}
+
+	while (n_dummy < FD_SETSIZE + 64) {
+		int fd = open("/dev/null", O_RDONLY | O_CLOEXEC);
+		if (fd < 0)
+			break;
+		dummy_fds[n_dummy++] = fd;
+		if (fd >= FD_SETSIZE - 1)
+			break;
+	}
+
+	if (n_dummy == 0 || dummy_fds[n_dummy - 1] < FD_SETSIZE - 1) {
+		fprintf(stderr,
+			"SKIP: could not push fd to FD_SETSIZE boundary "
+			"(FD_SETSIZE=%d, highest dummy fd=%d). "
+			"Try raising RLIMIT_NOFILE.\n",
+			FD_SETSIZE,
+			n_dummy > 0 ? dummy_fds[n_dummy - 1] : -1);
+		for (int i = 0; i < n_dummy; i++)
+			close(dummy_fds[i]);
+		free(dummy_fds);
+		close(srv.listenfd);
+		return EXIT_SUCCESS;
+	}
+
+	printf("Opened %d dummy fds; highest=%d. "
+	       "Next socket will be fd >= %d (FD_SETSIZE=%d).\n",
+		n_dummy,
+		dummy_fds[n_dummy - 1],
+		FD_SETSIZE,
+		FD_SETSIZE);
+
+	/* Step 4: start the server thread. */
+	pthread_create(&srv_tid, NULL, http_server_thread, &srv);
+
+	/* Step 5: call UpnpDownloadXmlDoc().  Internally this calls
+	 * private_connect() -> Check_Connect_And_Wait_Connection() with the
+	 * newly created socket whose fd >= FD_SETSIZE.
+	 *
+	 * OLD code: FD_SET(sock, &fdSet) with sock >= FD_SETSIZE overflows the
+	 *           fd_set bitmap; _FORTIFY_SOURCE calls abort() here.
+	 * FIXED code: poll() is used instead, no fd-number limit. */
+	snprintf(url,
+		sizeof(url),
+		"http://127.0.0.1:%u/test.xml",
+		(unsigned)srv.port);
+	printf("Calling UpnpDownloadXmlDoc(%s) ...\n", url);
+	rc = UpnpDownloadXmlDoc(url, &doc);
+
+	pthread_join(srv_tid, NULL);
+	close(srv.listenfd);
+
+	if (doc)
+		ixmlDocument_free(doc);
+
+	for (int i = 0; i < n_dummy; i++)
+		close(dummy_fds[i]);
+	free(dummy_fds);
+
+	/* Any return code other than a crash is acceptable: the important
+	 * thing is that Check_Connect_And_Wait_Connection did not abort(). */
+	if (rc == UPNP_E_SUCCESS) {
+		printf("UpnpDownloadXmlDoc: OK (XML document received)\n");
+	} else {
+		printf("UpnpDownloadXmlDoc returned %d "
+		       "(non-fatal: connection path ran without FD_SET "
+		       "crash)\n",
+			rc);
+	}
+
+	printf("test_connect_high_fd: PASS\n");
+	return EXIT_SUCCESS;
+}
+
+#else /* _WIN32 */
+
+int main(void)
+{
+	/* Windows fd_set uses an array of SOCKET handles, not a bitmap,
+	 * so FD_SETSIZE overflow does not apply here. */
+	printf("test_connect_high_fd: SKIP (not applicable on Windows)\n");
+	return EXIT_SUCCESS;
+}
+
+#endif /* _WIN32 */

--- a/upnp/test/test_gena_subscribe_pressure.c
+++ b/upnp/test/test_gena_subscribe_pressure.c
@@ -195,7 +195,24 @@ int main(void)
 
 	signal(SIGPIPE, SIG_IGN);
 
-	rc = UpnpInit2(NULL, 0);
+	/* Bind explicitly to loopback rather than NULL (all interfaces).
+	 *
+	 * When NULL is used, UpnpGetServerIpAddress() returns the runner's
+	 * real IP (e.g. 10.x.x.x on cloud CI).  health_check() then sends a
+	 * SUBSCRIBE with "Callback: <http://10.x.x.x:1/healthcheck>".  On
+	 * subscription acceptance the UPnP stack immediately fires a NOTIFY
+	 * to that callback URL, which means private_connect() opens a
+	 * non-blocking TCP socket to 10.x.x.x:1.  On cloud CI the SYN is
+	 * silently dropped by the network (no RST), so poll() waits for the
+	 * full DEFAULT_TCP_CONNECT_TIMEOUT (5 s) before giving up.
+	 * UpnpFinish() then blocks waiting for the NOTIFY thread, pushing
+	 * the test over the 5-second ctest budget.
+	 *
+	 * With "127.0.0.1", server_ip is always 127.0.0.1, the NOTIFY goes
+	 * to 127.0.0.1:1, and the loopback stack returns RST immediately
+	 * (nothing is listening on port 1), so poll() returns in
+	 * microseconds. */
+	rc = UpnpInit2("127.0.0.1", 0);
 	if (rc != UPNP_E_SUCCESS) {
 		fprintf(stderr,
 			"UpnpInit2 failed (%d); skipping (no network?)\n",


### PR DESCRIPTION
## Summary

- **Root cause:** `Check_Connect_And_Wait_Connection()` in `httpreadwrite.c` called `FD_SET(sock, &fdSet)` unconditionally. When a process has many open file descriptors (e.g., on a network busy with UPnP devices), the socket `fd` can exceed `FD_SETSIZE` (1024). With `_FORTIFY_SOURCE`, glibc's `__fdelt_chk()` aborts immediately; without it the `fd_set` bitmap overflows silently, corrupting adjacent stack memory — the crash reported in #423.
- **Fix:** mirror the `poll()` approach already in `sock_read_write()` (`sock.c`). On non-Windows, use `struct pollfd` + `poll()` instead of `fd_set` + `select()`. Windows path is unchanged (`fd_set` on Windows is array-based, not a bitmap, so no overflow).
- **Test:** `test_connect_high_fd.c` — opens 1020 dummy fds to push new socket fds above 1024, then calls `UpnpDownloadXmlDoc()` against a local HTTP server. With old code + `_FORTIFY_SOURCE=2`: aborts with *"bit out of range 0 - FD_SETSIZE"*. With fix: passes.
- **CI:** removed `UPNP_ENABLE_BLOCKING_TCP_CONNECTIONS=ON` from `cmake_common_flags` (it compiled out the buggy function entirely, so neither the fix nor the test was ever exercised); added `-O1 -D_FORTIFY_SOURCE=2` to Linux Debug builds so `FD_SET` overflows are caught at runtime.

## Test plan

- [x] All existing tests pass (`ctest --timeout 5`)
- [x] `test-upnp-connect-high-fd` passes with fix, aborts without it (verified locally with `_FORTIFY_SOURCE=2`)
- [x] Linux CI Debug build shows the new test in the passing list