### PR TITLE
fix: silence compiler warnings from CI debug flags

### DIFF
--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -208,7 +208,7 @@ static int getNumericHostRedirection(
 	struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)&addr;
 	socklen_t addr_len = sizeof addr;
 	in_port_t port;
-	char host[NAME_SIZE];
+	char host[INET6_ADDRSTRLEN];
 	int n;
 
 	rc = getsockname(socket, (struct sockaddr *)&addr, &addr_len);

--- a/upnp/src/genlib/net/sock.c
+++ b/upnp/src/genlib/net/sock.c
@@ -241,7 +241,7 @@ static int sock_read_write(SOCKINFO *info,
 #ifdef UPNP_ENABLE_OPEN_SSL
 			if (info->ssl) {
 				numBytes = (long)SSL_read(
-					info->ssl, buffer, bufsize);
+					info->ssl, buffer, (int)bufsize);
 			} else {
 #endif
 				/* read data. */
@@ -263,7 +263,7 @@ static int sock_read_write(SOCKINFO *info,
 				if (info->ssl) {
 					num_written = SSL_write(info->ssl,
 						buffer + bytes_sent,
-						byte_left);
+						(int)byte_left);
 				} else {
 #endif
 					/* write data. */

--- a/upnp/src/urlconfig/urlconfig.c
+++ b/upnp/src/urlconfig/urlconfig.c
@@ -196,7 +196,14 @@ static UPNP_INLINE int calc_descURL(
 	      (size_t)1;
 	if (len > (size_t)LINE_SIZE)
 		return UPNP_E_URL_TOO_BIG;
-	snprintf(descURL, len, "%s%s%s", http_scheme, ipPortStr, alias);
+		/* len <= LINE_SIZE verified above; GCC cannot prove it
+		 * statically */
+		/* clang-format off */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+	snprintf(descURL, LINE_SIZE, "%s%s%s", http_scheme, ipPortStr, alias);
+#pragma GCC diagnostic pop
+	/* clang-format on */
 	UpnpPrintf(
 		UPNP_INFO, API, __FILE__, __LINE__, "desc url: %s\n", descURL);
 


### PR DESCRIPTION
## Summary

Three compiler warnings surfaced when aligning the local build script
with the CI debug flags (`-O1 -D_FORTIFY_SOURCE=2`,
`-DUPNP_ENABLE_OPEN_SSL=ON`, `-DUPNP_ENABLE_UNSPECIFIED_SERVER=ON`).

- **miniserver.c**: Change `host[NAME_SIZE]` to `host[INET6_ADDRSTRLEN]`
  so GCC knows the true upper bound of `inet_ntop` output and stops
  flagging the `snprintf` calls with `-Wformat-truncation`.
- **sock.c**: Add `(int)` casts to `bufsize` and `byte_left` when
  calling `SSL_read`/`SSL_write`, consistent with the existing cast on
  the Windows `recv` path (`-Wconversion`).
- **urlconfig.c**: The `len > LINE_SIZE` guard makes the `snprintf`
  safe, but GCC cannot prove it statically. Wrap the call in a targeted
  `#pragma GCC diagnostic` block with a `clang-format off/on` guard
  (`-Wformat-truncation`).

## Test plan

- [x] Build locally with `scripts/comp-cmake.sh` — no warnings
- [x] All 34 ctest tests pass
- [x] CI green on all platforms