### PR TITLE
feat: add UpnpGetSsdpReqPort4/6() to query SSDP M-SEARCH source port

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 *******************************************************************************
-Version 1.18.6
+Version 1.20.0
 *******************************************************************************
 
 - Issue #178: ThreadPool: print backtrace on first "too many jobs" via new
@@ -7,6 +7,8 @@ Version 1.18.6
   (enabled by default; requires execinfo.h).
 - Issue #178: raise DEFAULT_MAX_JOBS_TOTAL from 100 to 1000 to better handle
   networks with many UPnP devices.
+- Issue #410: Add UpnpGetSsdpReqPort4() and UpnpGetSsdpReqPort6() to query
+  the OS-assigned source port used for SSDP M-SEARCH requests.
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 | branch         | status                                                                                              |
 | -------------- | --------------------------------------------------------------------------------------------------- |
-| main  (1.18.x) | ![main](https://github.com/pupnp/pupnp/workflows/Build/badge.svg)                                   |
+| main  (1.20.x) | ![main](https://github.com/pupnp/pupnp/workflows/Build/badge.svg)                                   |
+| branch-1.18.x  | ![1.18.x](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=branch-1.18.x) |
 | branch-1.14.x  | ![1.14.x](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=branch-1.14.x) |
 | branch-1.12.x  | ![1.12.x](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=branch-1.12.x) |
 | branch-1.10.x  | ![1.10.x](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=branch-1.10.x) |

--- a/configure.ac
+++ b/configure.ac
@@ -23,11 +23,22 @@ dnl #
 dnl # *please update only once, before a formal release, not for each change*
 dnl #
 dnl ############################################################################
-AC_INIT([libupnp],[1.18.6],[mroberto@users.sourceforge.net])
+AC_INIT([libupnp],[1.20.0],[mroberto@users.sourceforge.net])
 AC_SUBST([LT_VERSION_IXML], [12:8:1])
-AC_SUBST([LT_VERSION_UPNP], [20:6:0])
+AC_SUBST([LT_VERSION_UPNP], [21:0:1])
 dnl ############################################################################
-dnl # Release 1.18.6
+dnl # Release 1.20.0 (next)
+dnl # "current:revision:age"
+dnl #
+dnl # - Interfaces added in upnp: UpnpGetSsdpReqPort4, UpnpGetSsdpReqPort6
+dnl #   current: 20 -> 21
+dnl #   revision: 6 -> 0
+dnl #   age: 0 -> 1
+dnl #
+dnl #AC_SUBST([LT_VERSION_IXML], [12:8:1])
+dnl #AC_SUBST([LT_VERSION_UPNP], [21:0:1])
+dnl ############################################################################
+dnl # Release 1.20.0
 dnl # "current:revision:age"
 dnl #
 dnl # - Code has changed in upnp

--- a/upnp/inc/upnp.h
+++ b/upnp/inc/upnp.h
@@ -636,6 +636,32 @@ UPNP_EXPORT_SPEC unsigned short UpnpGetServerPort6(void);
 UPNP_EXPORT_SPEC unsigned short UpnpGetServerUlaGuaPort6(void);
 
 /*!
+ * \brief Returns the source IPv4 port used for SSDP M-SEARCH requests.
+ *
+ * The port is assigned by the OS on the first call to \b UpnpSearchAsync.
+ * Call this function after \b UpnpSearchAsync to retrieve the assigned port.
+ *
+ * \return
+ * 	\li On success: The IPv4 source port used for SSDP M-SEARCH requests.
+ * 	\li On error: 0 if \b UpnpInit2 has not succeeded, client APIs are
+ * 		not enabled, or no search has been performed yet.
+ */
+UPNP_EXPORT_SPEC unsigned short UpnpGetSsdpReqPort4(void);
+
+/*!
+ * \brief Returns the source IPv6 port used for SSDP M-SEARCH requests.
+ *
+ * The port is assigned by the OS on the first call to \b UpnpSearchAsync.
+ * Call this function after \b UpnpSearchAsync to retrieve the assigned port.
+ *
+ * \return
+ * 	\li On success: The IPv6 source port used for SSDP M-SEARCH requests.
+ * 	\li On error: 0 if \b UpnpInit2 has not succeeded, IPv6 or client APIs
+ * 		are not enabled, or no search has been performed yet.
+ */
+UPNP_EXPORT_SPEC unsigned short UpnpGetSsdpReqPort6(void);
+
+/*!
  * \brief Returns the local IPv4 listening ip address.
  *
  * If \c NULL is used as the interface in \b UpnpInit2, then this function can

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -787,6 +787,40 @@ unsigned short UpnpGetServerUlaGuaPort6(void)
 #endif
 }
 
+unsigned short UpnpGetSsdpReqPort4(void)
+{
+#ifdef INCLUDE_CLIENT_APIS
+	struct sockaddr_storage ss;
+	socklen_t len = sizeof(ss);
+	if (UpnpSdkInit != 1)
+		return 0u;
+	if (gSsdpReqSocket4 == INVALID_SOCKET)
+		return 0u;
+	if (getsockname(gSsdpReqSocket4, (struct sockaddr *)&ss, &len) != 0)
+		return 0u;
+	return ntohs(((struct sockaddr_in *)&ss)->sin_port);
+#else
+	return 0u;
+#endif
+}
+
+unsigned short UpnpGetSsdpReqPort6(void)
+{
+#if defined(INCLUDE_CLIENT_APIS) && defined(UPNP_ENABLE_IPV6)
+	struct sockaddr_storage ss;
+	socklen_t len = sizeof(ss);
+	if (UpnpSdkInit != 1)
+		return 0u;
+	if (gSsdpReqSocket6 == INVALID_SOCKET)
+		return 0u;
+	if (getsockname(gSsdpReqSocket6, (struct sockaddr *)&ss, &len) != 0)
+		return 0u;
+	return ntohs(((struct sockaddr_in6 *)&ss)->sin6_port);
+#else
+	return 0u;
+#endif
+}
+
 char *UpnpGetServerIpAddress(void)
 {
 	if (UpnpSdkInit != 1)

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -3,6 +3,7 @@ UPNP_Add_Unit_Test(test-upnp-init test_init.c)
 UPNP_Add_Unit_Test(test-upnp-log test_log.c)
 UPNP_Add_Unit_Test(test-upnp-url test_url.c)
 UPNP_Add_Unit_Test(test-upnp-sock-io test_sock_io.c)
+UPNP_Add_Unit_Test(test-upnp-ssdp-req-port test_ssdp_req_port.c)
 # test_threadpool_overflow calls internal ThreadPool API (ThreadPoolInit,
 # TPAttrInit, …) that have hidden visibility in the shared library.  Compile
 # the three ThreadPool translation units directly into each test variant so

--- a/upnp/test/test_ssdp_req_port.c
+++ b/upnp/test/test_ssdp_req_port.c
@@ -1,0 +1,117 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*- */
+/**************************************************************************
+ *
+ * Copyright (c) 2026 The pupnp contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************/
+
+/*!
+ * \file
+ * \brief Regression test for issue #410: UpnpGetSsdpReqPort4/6().
+ *
+ * Verifies that after UpnpSearchAsync() the new accessors return a
+ * non-zero ephemeral port for IPv4 (and, when IPv6 is available, for IPv6).
+ */
+
+#include "upnp.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "ithread.h" /* for imillisleep */
+
+#include "posix_overwrites.h" /* IWYU pragma: keep */
+
+static int discovery_callback(
+	Upnp_EventType event_type, void *event, void *cookie)
+{
+	(void)event_type;
+	(void)event;
+	(void)cookie;
+	return 0;
+}
+
+int main(void)
+{
+	int rc;
+	UpnpClient_Handle handle = -1;
+	unsigned short port4;
+	unsigned short port6;
+
+	printf("Initializing UPnP stack ... ");
+	fflush(stdout);
+	rc = UpnpInit2(NULL, 0);
+	if (rc != UPNP_E_SUCCESS) {
+		printf("FAIL (UpnpInit2 returned %d)\n", rc);
+		exit(EXIT_FAILURE);
+	}
+	printf("OK\n");
+
+	printf("Registering control point ... ");
+	fflush(stdout);
+	rc = UpnpRegisterClient(discovery_callback, NULL, &handle);
+	if (rc != UPNP_E_SUCCESS) {
+		printf("FAIL (UpnpRegisterClient returned %d)\n", rc);
+		UpnpFinish();
+		exit(EXIT_FAILURE);
+	}
+	printf("OK\n");
+
+	printf("Sending SSDP search (Mx=1s) ... ");
+	fflush(stdout);
+	rc = UpnpSearchAsync(handle, 1, "ssdp:all", NULL);
+	if (rc != UPNP_E_SUCCESS) {
+		printf("FAIL (UpnpSearchAsync returned %d)\n", rc);
+		UpnpUnRegisterClient(handle);
+		UpnpFinish();
+		exit(EXIT_FAILURE);
+	}
+	printf("OK\n");
+
+	/* Wait for the OS to assign the ephemeral port on first sendto(). */
+	imillisleep(500);
+
+	port4 = UpnpGetSsdpReqPort4();
+	printf("UpnpGetSsdpReqPort4() = %hu\n", port4);
+	if (port4 == 0) {
+		printf("FAIL (expected a non-zero ephemeral port for IPv4)\n");
+		UpnpUnRegisterClient(handle);
+		UpnpFinish();
+		exit(EXIT_FAILURE);
+	}
+
+	port6 = UpnpGetSsdpReqPort6();
+	printf("UpnpGetSsdpReqPort6() = %hu (0 if IPv6 not available)\n",
+		port6);
+
+	/* Wait for the search Mx timer to expire. */
+	imillisleep(1000);
+
+	UpnpUnRegisterClient(handle);
+	UpnpFinish();
+
+	printf("test_ssdp_req_port: PASS\n");
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
## Summary

Closes #410.

The SSDP request sockets (`gSsdpReqSocket4`/`gSsdpReqSocket6`) are created without an explicit `bind()`, so the OS assigns an ephemeral source port on the first `sendto()`. Previously there was no public API to discover this port.

- Add `UpnpGetSsdpReqPort4()` and `UpnpGetSsdpReqPort6()`, modelled after the existing `UpnpGetServerPort()`/`UpnpGetServerPort6()` accessors. They call `getsockname()` on the internal sockets and return the OS-assigned port. Call them after `UpnpSearchAsync()` to retrieve the value; they return 0 before any search is performed.
- Add `test_ssdp_req_port` to the test suite to verify both accessors return a non-zero port after a search.
- Bump libtool version `20:6:0` → `21:0:1` (new interfaces added; SONAME stays at 20).
- Bump package version to `1.20.0` following the project's even-minor-number convention for feature releases.
- Add `branch-1.18.x` at the `release-1.18.5` tag to preserve the 1.18 maintenance series.

## Test plan

- [x] `test-upnp-ssdp-req-port` and `test-upnp-ssdp-req-port-static` pass locally (verified: port4=32994, port6=48727)
- [x] CI green on all platforms (ubuntu, macos, windows, OmniOS, MinGW variants)