### PR TITLE
ci: restrict CIFuzz to C/C++ file changes

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - "!no_ci-*"
+    paths:
+      - "**.c"
+      - "**.cpp"
+      - "**.h"
+      - "**.hpp"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Add `paths` filter to the `CIFuzz` workflow so it only runs when `.c`, `.cpp`, `.h`, or `.hpp` files change

## Motivation

CIFuzz runs a 5-minute fuzzing job. There is no reason to trigger it on doc-only PRs (Markdown edits, `docs/` changes, etc.). This matches the same `paths` filter applied to `lint-clang-format` in #565.

## Test plan

- [ ] Verify this PR's CIFuzz job is skipped (it touches only a `.yml` file, confirming the filter works)
- [ ] Open a doc-only PR and confirm CIFuzz does not run
- [ ] Open a PR with a C/C++ change and confirm CIFuzz runs normally