### PR TITLE
fix: allow explicitly-named non-multicast interfaces in UpnpGetIfInfo

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,3 +40,14 @@ endif()
 set_tests_properties(test-init-py PROPERTIES
 	ENVIRONMENT "${_test_init_py_env}"
 )
+
+add_test(
+	NAME test-issue-110-py
+	COMMAND ${Python3_EXECUTABLE} -m pytest
+		${CMAKE_CURRENT_SOURCE_DIR}/test_issue_110.py
+		-v
+)
+
+set_tests_properties(test-issue-110-py PROPERTIES
+	ENVIRONMENT "${_test_init_py_env}"
+)

--- a/tests/test_issue_110.py
+++ b/tests/test_issue_110.py
@@ -1,0 +1,113 @@
+# regression: issue #110
+import ctypes
+import ctypes.util
+import os
+import socket
+import struct
+import fcntl
+import pytest
+
+UPNP_E_SUCCESS = 0
+UPNP_E_INVALID_INTERFACE = -121
+IFF_UP        = 0x1
+IFF_LOOPBACK  = 0x8
+IFF_MULTICAST = 0x1000
+SIOCGIFFLAGS  = 0x8913
+
+# To run the pointopoint test, create a non-multicast ipip tunnel as root:
+#
+#   sudo ip link add ipip_test type ipip local 127.0.0.1 remote 127.0.0.2
+#   sudo ip addr add 10.99.0.1/24 dev ipip_test
+#   sudo ip link set ipip_test up
+#
+# Root is required because creating tunnel interfaces and assigning addresses
+# are privileged kernel operations (CAP_NET_ADMIN).  Tear down afterwards with:
+#
+#   sudo ip link delete ipip_test
+
+
+def _get_if_flags(ifname: str) -> int:
+    """Return interface flags via ioctl, or -1 if unavailable."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        ifreq = struct.pack("16sh", ifname.encode()[:15], 0)
+        result = fcntl.ioctl(s.fileno(), SIOCGIFFLAGS, ifreq)
+        s.close()
+        return struct.unpack("16sh", result)[1]
+    except Exception:
+        return -1
+
+
+def _find_pointopoint_interface():
+    """Return the name of an UP, non-loopback, non-multicast interface, or None."""
+    try:
+        with open("/proc/net/dev") as f:
+            for line in f:
+                parts = line.split(":")
+                if len(parts) < 2:
+                    continue
+                name = parts[0].strip()
+                flags = _get_if_flags(name)
+                if flags == -1:
+                    continue
+                if (flags & IFF_UP) and not (flags & IFF_LOOPBACK) and not (flags & IFF_MULTICAST):
+                    return name
+    except FileNotFoundError:
+        pass
+    return None
+
+
+_POINTOPOINT_SETUP = (
+    "No UP non-multicast interface found (e.g. ipip_test). "
+    "To enable this test, run as root:\n"
+    "  sudo ip link add ipip_test type ipip local 127.0.0.1 remote 127.0.0.2\n"
+    "  sudo ip addr add 10.99.0.1/24 dev ipip_test\n"
+    "  sudo ip link set ipip_test up\n"
+    "Root is required because creating tunnel interfaces and assigning "
+    "addresses are privileged kernel operations (CAP_NET_ADMIN)."
+)
+
+
+@pytest.fixture(scope="module")
+def lib():
+    build_dir = os.environ.get("UPNP_BUILD_DIR", "")
+    if build_dir:
+        candidate = os.path.join(build_dir, "upnp", "libupnp.so")
+        path = candidate if os.path.exists(candidate) else None
+    else:
+        path = ctypes.util.find_library("upnp")
+    if path is None:
+        pytest.skip("libupnp not found; set UPNP_BUILD_DIR or install the library")
+    handle = ctypes.CDLL(path)
+    handle.UpnpInit2.restype = ctypes.c_int
+    handle.UpnpInit2.argtypes = [ctypes.c_char_p, ctypes.c_ushort]
+    handle.UpnpFinish.restype = ctypes.c_int
+    handle.UpnpFinish.argtypes = []
+    return handle
+
+
+def test_explicit_pointopoint_interface_accepted(lib):
+    """regression: issue #110 — explicitly-named non-multicast interface must be accepted."""
+    ifname = _find_pointopoint_interface()
+    if ifname is None:
+        pytest.skip(_POINTOPOINT_SETUP)
+    rc = lib.UpnpInit2(ifname.encode(), 0)
+    try:
+        assert rc == UPNP_E_SUCCESS, (
+            f"UpnpInit2('{ifname}', 0) returned {rc}; "
+            f"expected {UPNP_E_SUCCESS} — non-multicast interface rejected even when explicitly named"
+        )
+    finally:
+        lib.UpnpFinish()
+
+
+def test_auto_select_skips_pointopoint(lib):
+    """regression: issue #110 guard — auto-select must still prefer multicast-capable interfaces."""
+    rc = lib.UpnpInit2(None, 0)
+    try:
+        assert rc in (UPNP_E_SUCCESS, UPNP_E_INVALID_INTERFACE, -203), (
+            f"UpnpInit2(NULL, 0) returned unexpected code {rc}"
+        )
+    finally:
+        if rc == UPNP_E_SUCCESS:
+            lib.UpnpFinish()

--- a/upnp/inc/upnpconfig.h.cm
+++ b/upnp/inc/upnpconfig.h.cm
@@ -43,21 +43,15 @@
 
 /** Major version of the library */
 #undef UPNP_VERSION_MAJOR
-#cmakedefine UPNP_VERSION_MAJOR ${UPNP_VERSION_MAJOR}
+#define UPNP_VERSION_MAJOR ${UPNP_VERSION_MAJOR}
 
 /** Minor version of the library */
 #undef UPNP_VERSION_MINOR
-#cmakedefine UPNP_VERSION_MINOR ${UPNP_VERSION_MINOR}
-#ifndef UPNP_VERSION_MINOR
-#	define UPNP_VERSION_MINOR 0
-#endif
+#define UPNP_VERSION_MINOR ${UPNP_VERSION_MINOR}
 
 /** Patch version of the library */
 #undef UPNP_VERSION_PATCH
-#cmakedefine UPNP_VERSION_PATCH ${UPNP_VERSION_PATCH}
-#ifndef UPNP_VERSION_PATCH
-#	define UPNP_VERSION_PATCH 0
-#endif
+#define UPNP_VERSION_PATCH ${UPNP_VERSION_PATCH}
 
 /** The library version (numeric) e.g. 10300 means version 1.3.0 */
 #define UPNP_VERSION \

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -3933,11 +3933,17 @@ int UpnpGetIfInfo(const char *IfName)
 	/* cycle through available interfaces and their addresses. */
 	for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
 		/* Skip LOOPBACK interfaces, DOWN interfaces, */
-		/* interfaces without address (e.g. bonded)*/
-		/* and interfaces that don't support MULTICAST. */
+		/* and interfaces without address (e.g. bonded). */
 		if (!ifa->ifa_addr || (ifa->ifa_flags & IFF_LOOPBACK) ||
-			(!(ifa->ifa_flags & IFF_UP)) ||
-			(!(ifa->ifa_flags & IFF_MULTICAST))) {
+			(!(ifa->ifa_flags & IFF_UP))) {
+			continue;
+		}
+		/* When auto-selecting, also skip interfaces that don't support
+		 * MULTICAST (e.g. point-to-point tunnels). When the caller
+		 * explicitly names an interface, honour that choice even
+		 * without MULTICAST — SSDP discovery will not work on it, but
+		 * the rest of the UPnP stack will. */
+		if (IfName == NULL && !(ifa->ifa_flags & IFF_MULTICAST)) {
 			continue;
 		}
 		if (ifname_found == 0) {


### PR DESCRIPTION
## Summary

- `upnpconfig.h.cm`: switch numeric version fields from `#cmakedefine` to plain `#define` so that a patch version of `0` is emitted correctly instead of `/* #undef */`
- `upnpapi.c`: apply the `IFF_MULTICAST` filter only during auto-selection (`IfName == NULL`); when the caller explicitly names an interface, honour that choice even if it lacks multicast support (SSDP discovery will not work on such interfaces, but the rest of the UPnP stack will)
- `tests/test_issue_110.py`: regression tests covering the explicit non-multicast interface case and the auto-selection guard; wired into CTest via `tests/CMakeLists.txt`

Closes #110

## Test plan

- [x] `ctest` passes 38/38 serially
- [x] `test-issue-110-py` passes with an ipip tunnel present (`sudo ip link add ipip_test type ipip local 127.0.0.1 remote 127.0.0.2 && sudo ip addr add 10.99.0.1/24 dev ipip_test && sudo ip link set ipip_test up`)
- [x] `test-issue-110-py` skips cleanly with setup instructions when no non-multicast interface is available