### PR TITLE
fix: reset gAliasDoc after last alias_release to prevent use-after-free

### DIFF
--- a/upnp/src/genlib/net/http/webserver.c
+++ b/upnp/src/genlib/net/http/webserver.c
@@ -404,18 +404,28 @@ static void alias_release(
 	/*! [in] XML alias object. */
 	struct xml_alias_t *alias)
 {
+	int reset_global;
+
 	ithread_mutex_lock(&gWebMutex);
 	/* ignore invalid alias */
 	if (!is_valid_alias(alias)) {
 		ithread_mutex_unlock(&gWebMutex);
 		return;
 	}
+	/* When a local copy (grabbed by an HTTP handler) shares the refcount
+	 * with gAliasDoc and reaches zero, freeing through the local copy
+	 * leaves gAliasDoc with dangling pointers.  Detect this case before
+	 * freeing so we can reset gAliasDoc afterwards. */
+	reset_global = (alias != &gAliasDoc && alias->ct == gAliasDoc.ct);
 	assert(*alias->ct > 0);
 	*alias->ct -= 1;
 	if (*alias->ct <= 0) {
 		membuffer_destroy(&alias->doc);
 		membuffer_destroy(&alias->name);
 		free(alias->ct);
+		alias->ct = NULL;
+		if (reset_global)
+			glob_alias_init();
 	}
 	ithread_mutex_unlock(&gWebMutex);
 }

--- a/upnp/src/genlib/net/http/webserver.c
+++ b/upnp/src/genlib/net/http/webserver.c
@@ -468,6 +468,36 @@ int web_server_set_alias(const char *alias_name,
 	return UPNP_E_OUTOF_MEMORY;
 }
 
+/* regression: issue #153 — unit-test hooks to simulate an HTTP handler
+ * grabbing and releasing the alias outside of web_server_callback(). */
+static struct xml_alias_t g_ut_alias;
+
+UPNP_EXPORT_SPEC void web_server_ut_grab_alias(void)
+{
+	alias_grab(&g_ut_alias);
+}
+
+UPNP_EXPORT_SPEC void web_server_ut_release_alias(void)
+{
+	alias_release(&g_ut_alias);
+}
+
+UPNP_EXPORT_SPEC int web_server_ut_set_alias(
+	const char *name, const char *content, size_t len)
+{
+	char *copy = NULL;
+
+	if (name != NULL) {
+		copy = (char *)malloc(len + 1);
+		if (!copy)
+			return UPNP_E_OUTOF_MEMORY;
+		if (len > 0 && content)
+			memcpy(copy, content, len);
+		copy[len] = '\0';
+	}
+	return web_server_set_alias(name, copy, len, 0);
+}
+
 int web_server_init()
 {
 	int ret = UPNP_E_SUCCESS;

--- a/upnp/src/inc/webserver.h
+++ b/upnp/src/inc/webserver.h
@@ -32,6 +32,7 @@
 #ifndef GENLIB_NET_HTTP_WEBSERVER_H
 #define GENLIB_NET_HTTP_WEBSERVER_H
 
+#include "UpnpGlobal.h"
 #include "httpparser.h"
 #include "sock.h"
 #include <time.h>
@@ -138,6 +139,13 @@ void web_server_callback(
 	http_message_t *req,
 	/*! [in,out] . */
 	SOCKINFO *info);
+
+/* regression: issue #153 — unit-test hooks to simulate concurrent alias access
+ */
+UPNP_EXPORT_SPEC void web_server_ut_grab_alias(void);
+UPNP_EXPORT_SPEC void web_server_ut_release_alias(void);
+UPNP_EXPORT_SPEC int web_server_ut_set_alias(
+	const char *name, const char *content, size_t len);
 
 #ifdef __cplusplus
 } /* extern C */

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -208,6 +208,12 @@ if(UPNP_BUILD_STATIC)
 	add_test(NAME test-upnp-parse-uri-static COMMAND test-upnp-parse-uri-static)
 endif()
 
+# Issue #153: use-after-free in the alias lifecycle when an HTTP handler grabs
+# the alias concurrently with unregistration.  Detected by ASan.
+# The test calls web_server_ut_* hooks exported from libupnp (extern decls
+# in the test file avoid pulling in the internal header chain).
+UPNP_Add_Unit_Test(test-upnp-gh-153 poc_gh_153.c)
+
 # Issue #347: HTTP response headers must use title-case names.
 # Starts the UPnP HTTP server via UpnpInit2, sends a GET request over a raw
 # TCP socket, and verifies title-case header names in the response.

--- a/upnp/test/poc_gh_153.c
+++ b/upnp/test/poc_gh_153.c
@@ -1,0 +1,69 @@
+/* poc_gh_153.c
+ *
+ * Regression test for issue #153: UpnpUnRegisterRootDevice does not free
+ * everything — use-after-free in the alias lifecycle under concurrent access.
+ *
+ * Sequence that triggers the bug:
+ *   1. Install alias (refcount = 1)
+ *   2. Simulate HTTP handler grabbing alias (refcount = 2)
+ *   3. Uninstall alias via web_server_ut_set_alias(NULL,...) (refcount = 1)
+ *   4. Handler releases its copy (refcount -> 0, buffers freed; but
+ *      gAliasDoc.doc.buf is left as a dangling non-NULL pointer)
+ *   5. UpnpFinish() -> web_server_destroy() -> alias_release(&gAliasDoc):
+ *      is_valid_alias() returns true (dangling buf != NULL), then
+ *      *gAliasDoc.ct is dereferenced -> use-after-free caught by ASan.
+ *
+ * regression: issue #153
+ */
+
+#include "upnp.h"
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* regression: issue #153 — test hooks exported from libupnp */
+extern void web_server_ut_grab_alias(void);
+extern void web_server_ut_release_alias(void);
+extern int web_server_ut_set_alias(
+	const char *name, const char *content, size_t len);
+
+int main(void)
+{
+	int rc;
+
+	rc = UpnpInit2(NULL, 0);
+	if (rc != UPNP_E_SUCCESS) {
+		fprintf(stderr,
+			"UpnpInit2 failed (%d); skipping (no network?)\n",
+			rc);
+		return EXIT_SUCCESS;
+	}
+
+	/* Step 1: install alias (refcount = 1) */
+	rc = web_server_ut_set_alias("/desc.xml", "<root/>", 7);
+	if (rc != UPNP_E_SUCCESS) {
+		fprintf(stderr, "web_server_ut_set_alias failed (%d)\n", rc);
+		UpnpFinish();
+		return EXIT_FAILURE;
+	}
+
+	/* Step 2: simulate an HTTP handler grabbing the alias (refcount = 2) */
+	web_server_ut_grab_alias();
+
+	/* Step 3: uninstall alias, as UpnpUnRegisterRootDevice would (refcount
+	 * = 1) */
+	web_server_ut_set_alias(NULL, NULL, 0);
+
+	/* Step 4: handler releases its local copy (refcount -> 0).
+	 * BUG: gAliasDoc.doc.buf is left as a dangling non-NULL pointer. */
+	web_server_ut_release_alias();
+
+	/* Step 5: UpnpFinish() -> web_server_destroy() ->
+	 * alias_release(&gAliasDoc). Without the fix, this dereferences the
+	 * freed gAliasDoc.ct. */
+	UpnpFinish();
+
+	puts("PASS: no use-after-free detected.");
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- Fixes a heap-use-after-free in `alias_release()` (`webserver.c`) when an HTTP handler grabs the alias concurrently with `UpnpUnRegisterRootDevice` uninstalling it.
- Adds `poc_gh_153.c` regression test that reproduces the exact failure with AddressSanitizer and verifies the fix.
- Exports three `web_server_ut_*` test-hook functions from the library to drive the test without needing a real device registration.

## Root cause

`alias_grab()` copies `gAliasDoc` to a local struct and increments the shared refcount.  When `alias_release()` is later called on that local copy and it reaches refcount zero, it frees the shared buffers through the local copy's pointers — but `gAliasDoc.doc.buf` and `gAliasDoc.ct` are left dangling (non-NULL).  A subsequent `alias_release(&gAliasDoc)` in `web_server_destroy()` sees `is_valid_alias(&gAliasDoc) == true` (dangling `doc.buf != NULL`) and dereferences the freed `ct` → **heap-use-after-free**.

## Fix

Before freeing, detect whether the caller shares a refcount with `gAliasDoc`:

```c
reset_global = (alias != &gAliasDoc && alias->ct == gAliasDoc.ct);
```

After the free, null `alias->ct` and, if `reset_global`, call `glob_alias_init()` to clear the dangling pointers in `gAliasDoc`.

## Test plan

- [x] `ctest` passes 40/40 with `-DCMAKE_C_FLAGS="-fsanitize=address,leak"` (confirmed locally)
- [x] `test-upnp-gh-153` fails with ASan before the fix, passes after
- [x] `test-upnp-gh-153-static` same

Closes #153