### PR TITLE
fix: UpnpInit2 returns UPNP_E_SOCKET_BIND after network interface change (issue #195)

### DIFF
--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -17,3 +17,26 @@ endif()
 #		ADDITIONAL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../upnp/src/threadutil/
 #	)
 #endif()
+
+# regression test for issue #195 — accesses internal symbols (gIF_IPV6 etc.)
+# that have hidden visibility in the shared library, so only the static variant
+# is built.
+if (NOT WIN32 AND UPNP_BUILD_STATIC)
+	include(GoogleTest)
+	add_executable(test_miniserver-static test_miniserver.cpp)
+	target_link_libraries(test_miniserver-static PRIVATE upnp_static GTest::gmock)
+	target_include_directories(test_miniserver-static PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../upnp/src/inc/
+		${CMAKE_CURRENT_SOURCE_DIR}/../upnp/src/threadutil/
+	)
+	if(HAVE_MACRO_PREFIX_MAP)
+		target_compile_options(test_miniserver-static
+			PRIVATE -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=
+		)
+	endif()
+	gtest_add_tests(
+		TARGET test_miniserver-static
+		TEST_PREFIX test-upnp-
+		TEST_SUFFIX -static
+	)
+endif()

--- a/gtest/test_miniserver.cpp
+++ b/gtest/test_miniserver.cpp
@@ -1,0 +1,149 @@
+// regression: issue #195
+// UpnpInit2 returns UPNP_E_SOCKET_BIND after a network interface change.
+//
+// Root cause: UpnpGetIfInfo() does not clear gIF_IPV6 before scanning.
+// When the interface changes and no longer has a link-local IPv6 address,
+// gIF_IPV6 retains the stale value from the previous initialization.
+// get_miniserver_sockets() then tries to bind a TCP socket to that stale
+// address, which fails with EADDRNOTAVAIL → UPNP_E_SOCKET_BIND.
+//
+// Fix: UpnpGetIfInfo() must clear gIF_IPV6 (and gIF_IPV6_ULA_GUA) before
+// scanning so stale addresses do not persist across re-initializations.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// Internal headers — needed for gIF_IPV6 and UpnpGetIfInfo()
+extern "C" {
+#include "upnpapi.h"
+}
+
+// Test helper tools (CIfaddr4, CCaptureFd)
+#include "tools/tools.cpp"
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <ifaddrs.h>
+#include <net/if.h>
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+// --- mock getifaddrs ---
+class MockGetifaddrs
+{
+public:
+	MOCK_METHOD(int, getifaddrs, (struct ifaddrs **));
+};
+MockGetifaddrs *ptrMockGetifaddrsObj = nullptr;
+int getifaddrs(struct ifaddrs **ifap)
+{
+	return ptrMockGetifaddrsObj->getifaddrs(ifap);
+}
+
+// --- mock freeifaddrs ---
+class MockFreeifaddrs
+{
+public:
+	MOCK_METHOD(void, freeifaddrs, (struct ifaddrs *));
+};
+MockFreeifaddrs *ptrMockFreeifaddrObj = nullptr;
+void freeifaddrs(struct ifaddrs *ifap)
+{
+	return ptrMockFreeifaddrObj->freeifaddrs(ifap);
+}
+
+// --- mock if_nametoindex ---
+class MockIf_nametoindex
+{
+public:
+	MOCK_METHOD(unsigned int, if_nametoindex, (const char *));
+};
+MockIf_nametoindex *ptrMockIf_nametoindexObj = nullptr;
+unsigned int if_nametoindex(const char *ifname)
+{
+	return ptrMockIf_nametoindexObj->if_nametoindex(ifname);
+}
+
+class Issue195TestSuite : public ::testing::Test
+{
+protected:
+	MockGetifaddrs mockGetifaddrsObj;
+	MockFreeifaddrs mockFreeifaddrObj;
+	MockIf_nametoindex mockIf_nametoindexObj;
+
+	Issue195TestSuite()
+	{
+		ptrMockGetifaddrsObj = &mockGetifaddrsObj;
+		ptrMockFreeifaddrObj = &mockFreeifaddrObj;
+		ptrMockIf_nametoindexObj = &mockIf_nametoindexObj;
+	}
+
+	void SetUp() override
+	{
+		gIF_IPV6[0] = '\0';
+		gIF_IPV6_PREFIX_LENGTH = 0;
+		gIF_IPV6_ULA_GUA[0] = '\0';
+		gIF_IPV6_ULA_GUA_PREFIX_LENGTH = 0;
+	}
+
+	void TearDown() override
+	{
+		gIF_IPV6[0] = '\0';
+		gIF_IPV6_ULA_GUA[0] = '\0';
+		ptrMockGetifaddrsObj = nullptr;
+		ptrMockFreeifaddrObj = nullptr;
+		ptrMockIf_nametoindexObj = nullptr;
+	}
+};
+
+// regression: issue #195
+// When UpnpGetIfInfo is called for an interface with no link-local IPv6,
+// it must clear gIF_IPV6 so that a stale address from a previous init
+// does not survive into the next StartMiniServer call.
+TEST_F(Issue195TestSuite, GetIfInfo_clears_stale_IPv6_when_interface_has_none)
+{
+	char *github_action = std::getenv("GITHUB_ACTIONS");
+	if (github_action) {
+		GTEST_SKIP() << "due to issues with googlemock";
+	}
+
+	// Simulate the state after a previous initialization that had IPv6:
+	// gIF_IPV6 holds a stale link-local address that no longer exists on
+	// the interface after a network change.
+	strncpy(gIF_IPV6, "fe80::dead:beef", INET6_ADDRSTRLEN - 1);
+	gIF_IPV6[INET6_ADDRSTRLEN - 1] = '\0';
+
+	// Mock getifaddrs to return an IPv4-only interface (simulates the
+	// state after a network change where the IPv6 address was removed).
+	struct ifaddrs *ifaddr = nullptr;
+	CIfaddr4 ifaddr4Obj;
+	ifaddr4Obj.set("eth0", "192.168.99.3/24");
+	ifaddr = ifaddr4Obj.get();
+
+	EXPECT_CALL(mockGetifaddrsObj, getifaddrs(_))
+		.WillOnce(DoAll(SetArgPointee<0>(ifaddr), Return(0)));
+	EXPECT_CALL(mockFreeifaddrObj, freeifaddrs(ifaddr)).Times(1);
+	EXPECT_CALL(mockIf_nametoindexObj, if_nametoindex(_))
+		.WillOnce(Return(2));
+
+	int rc = UpnpGetIfInfo("eth0");
+	EXPECT_EQ(rc, UPNP_E_SUCCESS);
+
+	// Before fix: gIF_IPV6 == "fe80::dead:beef" (stale, not cleared)
+	// After fix:  gIF_IPV6 == "" (cleared before scanning)
+	EXPECT_STREQ(gIF_IPV6, "")
+		<< "regression issue #195: UpnpGetIfInfo must clear gIF_IPV6 "
+		   "when the scanned interface has no link-local IPv6. "
+		   "A stale gIF_IPV6 causes get_miniserver_sockets to attempt "
+		   "a bind() to the old address, returning UPNP_E_SOCKET_BIND "
+		   "on every re-initialization after a network change.";
+}
+
+int main(int argc, char **argv)
+{
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -3938,6 +3938,13 @@ int UpnpGetIfInfo(const char *IfName)
 		strncpy(gIF_NAME, IfName, sizeof(gIF_NAME) - 1);
 		ifname_found = 1;
 	}
+	/* Clear stale IPv6 addresses from any previous initialization so that
+	 * a network change does not leave gIF_IPV6 pointing at an address
+	 * that no longer exists on the interface (issue #195). */
+	gIF_IPV6[0] = '\0';
+	gIF_IPV6_PREFIX_LENGTH = 0;
+	gIF_IPV6_ULA_GUA[0] = '\0';
+	gIF_IPV6_ULA_GUA_PREFIX_LENGTH = 0;
 	/* Get system interface addresses. */
 	if (getifaddrs(&ifap) != 0) {
 		UpnpPrintf(UPNP_CRITICAL,

--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -1460,13 +1460,38 @@ static int get_miniserver_sockets(
 	if (ss6.fd != INVALID_SOCKET) {
 		ret_val = do_bind_listen(&ss6);
 		if (ret_val) {
-			goto error;
+			/* IPv6 bind failed. Non-fatal when IPv4 is available
+			 * (issue #193, #195): fall back to IPv4-only. */
+			if (ss4.fd == INVALID_SOCKET) {
+				goto error;
+			}
+			UpnpPrintf(UPNP_INFO,
+				MSERV,
+				__FILE__,
+				__LINE__,
+				"get_miniserver_sockets: IPv6 bind failed, "
+				"continuing with IPv4 only\n");
+			sock_close(ss6.fd);
+			ss6.fd = INVALID_SOCKET;
 		}
 	}
 	if (ss6UlaGua.fd != INVALID_SOCKET) {
 		ret_val = do_bind_listen(&ss6UlaGua);
 		if (ret_val) {
-			goto error;
+			/* IPv6 ULA/GUA bind failed. Non-fatal when IPv4 or
+			 * IPv6 LLA is available. */
+			if (ss4.fd == INVALID_SOCKET &&
+				ss6.fd == INVALID_SOCKET) {
+				goto error;
+			}
+			UpnpPrintf(UPNP_INFO,
+				MSERV,
+				__FILE__,
+				__LINE__,
+				"get_miniserver_sockets: IPv6 ULA/GUA bind "
+				"failed, continuing without it\n");
+			sock_close(ss6UlaGua.fd);
+			ss6UlaGua.fd = INVALID_SOCKET;
 		}
 	}
 	UpnpPrintf(UPNP_INFO,


### PR DESCRIPTION
Fixes #195.

## Root cause

`UpnpGetIfInfo()` does not reset `gIF_IPV6` / `gIF_IPV6_ULA_GUA` before
scanning the interface.  When the application calls `UpnpFinish()` after
a successful initialization and then calls `UpnpInit2()` again after a
network change, the interface may no longer have a link-local IPv6 address.
In that case `UpnpGetIfInfo()` finds no IPv6 to write into the global, so
the stale address from the previous initialization survives.

`get_miniserver_sockets()` then calls `init_socket_stuff()` with the stale
address string.  `inet_pton()` accepts it (it is syntactically valid), a
socket is created, and `bind()` fails with `EADDRNOTAVAIL` because the
address no longer exists on the interface.  The current code treats this as
a hard error and returns `UPNP_E_SOCKET_BIND`, causing every subsequent
`UpnpInit2()` call to fail until the process is restarted.

The reporter observed that `--disable-ipv6` at configure time worked around
the problem, confirming the IPv6 code path as the source.

## Changes

**`upnp/src/api/upnpapi.c`** — primary fix  
Clear `gIF_IPV6`, `gIF_IPV6_ULA_GUA`, and their prefix lengths at the start
of `UpnpGetIfInfo()` before the `getifaddrs` scan.  This ensures that stale
addresses from a previous initialization can never survive across an
`UpnpFinish()` / `UpnpInit2()` cycle.

**`upnp/src/genlib/miniserver/miniserver.c`** — defense in depth  
Implement the design decision from issue #193: an IPv6 bind failure in
`get_miniserver_sockets()` is non-fatal when IPv4 is still available.  The
failed socket is closed and initialization continues IPv4-only.  This covers
the residual race condition where the new IPv6 address has not yet been
assigned by the time `UpnpGetIfInfo()` scans (e.g. IPv6 SLAAC delay).

**`gtest/test_miniserver.cpp`** / **`gtest/CMakeLists.txt`** — regression test  
Adds a gtest (static-only, since `gIF_IPV6` has hidden visibility in the
shared library) that reproduces the bug: sets `gIF_IPV6` to a stale
link-local address, calls `UpnpGetIfInfo()` with a mocked IPv4-only
interface, and asserts that `gIF_IPV6` is cleared to `""` after the call.
The test failed before the fix and passes after.

## Test results

```
100% tests passed, 0 tests failed out of 41
```