### PR TITLE
fix: remove MSG_DONTROUTE from send() in sock_read_write() (issue #395)

### DIFF
--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -40,3 +40,26 @@ if (NOT WIN32 AND UPNP_BUILD_STATIC)
 		TEST_SUFFIX -static
 	)
 endif()
+
+# regression test for issue #395 — sock_write must not pass MSG_DONTROUTE to
+# send() on TCP sockets; sock_write() is an internal symbol (hidden visibility
+# in the shared library) so only the static variant is built.
+if (NOT WIN32 AND UPNP_BUILD_STATIC)
+	include(GoogleTest)
+	add_executable(test_sock-static test_sock.cpp)
+	target_link_libraries(test_sock-static PRIVATE upnp_static GTest::gtest)
+	target_include_directories(test_sock-static PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../upnp/src/inc/
+		${CMAKE_CURRENT_SOURCE_DIR}/../upnp/src/threadutil/
+	)
+	if(HAVE_MACRO_PREFIX_MAP)
+		target_compile_options(test_sock-static
+			PRIVATE -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=
+		)
+	endif()
+	gtest_add_tests(
+		TARGET test_sock-static
+		TEST_PREFIX test-upnp-
+		TEST_SUFFIX -static
+	)
+endif()

--- a/gtest/test_sock.cpp
+++ b/gtest/test_sock.cpp
@@ -1,0 +1,71 @@
+// regression: issue #395
+// sock_read_write() passed MSG_DONTROUTE to send() unconditionally.
+// MSG_DONTROUTE is a no-op for TCP on Linux but causes send() to fail
+// on Fuchsia (EPFNOSUPPORT), making UpnpRegisterRootDevice4 always fail.
+//
+// Fix: remove MSG_DONTROUTE from the send() call in sock_read_write().
+// SSDP UDP sends go through sendto() directly and are unaffected.
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "sock.h"
+}
+
+#include <sys/socket.h>
+#include <unistd.h>
+
+class Issue395TestSuite : public ::testing::Test
+{
+protected:
+	int sv[2]{-1, -1};
+
+	void SetUp() override
+	{
+		ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+	}
+
+	void TearDown() override
+	{
+		if (sv[0] >= 0)
+			close(sv[0]);
+		if (sv[1] >= 0)
+			close(sv[1]);
+	}
+};
+
+// regression: issue #395
+// sock_write must succeed on a connected TCP-like socket.
+// On Fuchsia this failed because MSG_DONTROUTE is unsupported.
+TEST_F(Issue395TestSuite, sock_write_succeeds_over_socketpair)
+{
+	SOCKINFO info{};
+	info.socket = sv[0];
+	int timeout = 5;
+	const char msg[] = "hello";
+
+	int rc = sock_write(&info, msg, sizeof(msg) - 1, &timeout);
+	EXPECT_EQ(rc, (int)(sizeof(msg) - 1));
+}
+
+TEST_F(Issue395TestSuite, sock_write_data_received_intact)
+{
+	SOCKINFO info{};
+	info.socket = sv[0];
+	int timeout = 5;
+	const char msg[] = "hello";
+
+	int rc = sock_write(&info, msg, sizeof(msg) - 1, &timeout);
+	ASSERT_EQ(rc, (int)(sizeof(msg) - 1));
+
+	char buf[16]{};
+	ssize_t n = recv(sv[1], buf, sizeof(buf), 0);
+	ASSERT_EQ(n, (ssize_t)(sizeof(msg) - 1));
+	EXPECT_STREQ(buf, "hello");
+}
+
+int main(int argc, char **argv)
+{
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/upnp/src/genlib/net/sock.c
+++ b/upnp/src/genlib/net/sock.c
@@ -270,7 +270,7 @@ static int sock_read_write(SOCKINFO *info,
 					num_written = send(sockfd,
 						buffer + bytes_sent,
 						byte_left,
-						MSG_DONTROUTE | MSG_NOSIGNAL);
+						MSG_NOSIGNAL);
 #ifdef UPNP_ENABLE_OPEN_SSL
 				}
 #endif


### PR DESCRIPTION
## Summary

- `sock_read_write()` was passing `MSG_DONTROUTE | MSG_NOSIGNAL` to `send()` unconditionally.
- `MSG_DONTROUTE` is a documented no-op for TCP on Linux ([tcp.c:1444](https://elixir.bootlin.com/linux/latest/source/net/ipv4/tcp.c#L1444)), so this went unnoticed.
- On Fuchsia, `MSG_DONTROUTE` is unsupported and causes `send()` to fail, making `UpnpRegisterRootDevice4` always return an error.
- SSDP UDP sends use `sendto()` directly in `ssdp_ctrlpt.c` / `ssdp_device.c` — they do not go through `sock_read_write()` and are unaffected.

## Changes

- `upnp/src/genlib/net/sock.c`: remove `MSG_DONTROUTE` from the `send()` flags, keeping `MSG_NOSIGNAL`.
- `gtest/test_sock.cpp`: new regression test exercising `sock_write()` over a `socketpair`, confirming data is sent and received intact.
- `gtest/CMakeLists.txt`: register `test_sock-static` (static-only, since `sock_write` is an internal symbol with hidden visibility in the shared library).

## Test plan

- [ ] `ctest` passes 42/42 locally (Linux) after the fix
- [ ] No change in SSDP behaviour (SSDP uses `sendto()` directly, not `sock_write()`)
- [ ] Fixes `UpnpRegisterRootDevice4` failure on Fuchsia (cannot be verified in CI — reported by issue author)

Fixes #395