### PR TITLE
fix: accept RFC 1918 cross-subnet delivery URLs in GENA subscriptions (issue #379)

### DIFF
--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -41,6 +41,29 @@ if (NOT WIN32 AND UPNP_BUILD_STATIC)
 	)
 endif()
 
+# regression test for issue #379 — gena_validate_delivery_urls() must accept
+# cross-subnet delivery URLs when both device and subscriber are on RFC 1918
+# private addresses; accesses internal symbols so only the static variant.
+if (NOT WIN32 AND UPNP_BUILD_STATIC)
+	include(GoogleTest)
+	add_executable(test_gena-static test_gena.cpp)
+	target_link_libraries(test_gena-static PRIVATE upnp_static GTest::gtest)
+	target_include_directories(test_gena-static PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../upnp/src/inc/
+		${CMAKE_CURRENT_SOURCE_DIR}/../upnp/src/threadutil/
+	)
+	if(HAVE_MACRO_PREFIX_MAP)
+		target_compile_options(test_gena-static
+			PRIVATE -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=
+		)
+	endif()
+	gtest_add_tests(
+		TARGET test_gena-static
+		TEST_PREFIX test-upnp-
+		TEST_SUFFIX -static
+	)
+endif()
+
 # regression test for issue #395 — sock_write must not pass MSG_DONTROUTE to
 # send() on TCP sockets; sock_write() is an internal symbol (hidden visibility
 # in the shared library) so only the static variant is built.

--- a/gtest/test_gena.cpp
+++ b/gtest/test_gena.cpp
@@ -1,0 +1,111 @@
+// regression: issue #379
+// gena_validate_delivery_urls() must accept cross-subnet delivery URLs when
+// both the device and the subscriber are on RFC 1918 private addresses.
+//
+// Root cause: the CallStranger fix (PR #181) checks the delivery URL against
+// the device's configured netmask. In a multicast-routed environment the
+// device (192.168.10.34/24) and the subscriber (192.168.27.65/24) can be on
+// different /24 subnets but still both within the 192.168/16 private range.
+// The UPnP spec says "for private networks the delivery URL must adhere to
+// the RFC 1918 ranges", not "must be on the same subnet".
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "sock.h"
+#include "upnpapi.h"
+#include "uri.h"
+}
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <netinet/in.h>
+
+// Forward-declare the internal function (not exported in gena.h)
+extern "C" int gena_validate_delivery_urls(SOCKINFO *info, URL_list *url_list);
+
+static SOCKINFO make_sockinfo_ipv4(const char *peer_ip)
+{
+	SOCKINFO info{};
+	auto *sa =
+		reinterpret_cast<struct sockaddr_in *>(&info.foreign_sockaddr);
+	sa->sin_family = AF_INET;
+	inet_pton(AF_INET, peer_ip, &sa->sin_addr);
+	info.foreign_sockaddr.ss_family = AF_INET;
+	return info;
+}
+
+static URL_list make_url_list_ipv4(const char *delivery_ip)
+{
+	URL_list list{};
+	list.size = 1;
+	list.parsedURLs = new uri_type[1]{};
+	auto *sa = reinterpret_cast<struct sockaddr_in *>(
+		&list.parsedURLs[0].hostport.IPaddress);
+	sa->sin_family = AF_INET;
+	inet_pton(AF_INET, delivery_ip, &sa->sin_addr);
+	return list;
+}
+
+class GenaValidateDeliveryUrlsTest : public ::testing::Test
+{
+protected:
+	void TearDown() override
+	{
+		delete[] url_list_.parsedURLs;
+		url_list_.parsedURLs = nullptr;
+	}
+
+	SOCKINFO info_{};
+	URL_list url_list_{};
+};
+
+// Regression guard: same /24 subnet — must still be accepted after the fix.
+TEST_F(GenaValidateDeliveryUrlsTest, same_subnet_accepted)
+{
+	strncpy(gIF_IPV4, "192.168.10.34", sizeof(gIF_IPV4));
+	strncpy(gIF_IPV4_NETMASK, "255.255.255.0", sizeof(gIF_IPV4_NETMASK));
+	info_ = make_sockinfo_ipv4("192.168.10.1");
+	url_list_ = make_url_list_ipv4("192.168.10.100");
+
+	EXPECT_EQ(gena_validate_delivery_urls(&info_, &url_list_), 0);
+}
+
+// Core regression: cross-subnet but same RFC 1918 192.168/16 block.
+TEST_F(GenaValidateDeliveryUrlsTest, cross_subnet_same_rfc1918_192_168_accepted)
+{
+	strncpy(gIF_IPV4, "192.168.10.34", sizeof(gIF_IPV4));
+	strncpy(gIF_IPV4_NETMASK, "255.255.255.0", sizeof(gIF_IPV4_NETMASK));
+	info_ = make_sockinfo_ipv4("192.168.10.1");
+	url_list_ = make_url_list_ipv4("192.168.27.65");
+
+	EXPECT_EQ(gena_validate_delivery_urls(&info_, &url_list_), 0);
+}
+
+// Cross-RFC1918-class: device on 10/8, delivery on 192.168/16 — both private.
+TEST_F(GenaValidateDeliveryUrlsTest, cross_rfc1918_class_10_to_192_accepted)
+{
+	strncpy(gIF_IPV4, "10.0.1.1", sizeof(gIF_IPV4));
+	strncpy(gIF_IPV4_NETMASK, "255.0.0.0", sizeof(gIF_IPV4_NETMASK));
+	info_ = make_sockinfo_ipv4("10.0.0.1");
+	url_list_ = make_url_list_ipv4("192.168.27.65");
+
+	EXPECT_EQ(gena_validate_delivery_urls(&info_, &url_list_), 0);
+}
+
+// Regression guard: public delivery URL must always be rejected.
+TEST_F(GenaValidateDeliveryUrlsTest, public_delivery_url_rejected)
+{
+	strncpy(gIF_IPV4, "192.168.10.34", sizeof(gIF_IPV4));
+	strncpy(gIF_IPV4_NETMASK, "255.255.255.0", sizeof(gIF_IPV4_NETMASK));
+	info_ = make_sockinfo_ipv4("192.168.10.1");
+	url_list_ = make_url_list_ipv4("203.0.113.5");
+
+	EXPECT_EQ(gena_validate_delivery_urls(&info_, &url_list_), -1);
+}
+
+int main(int argc, char **argv)
+{
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/upnp/src/gena/gena_device.c
+++ b/upnp/src/gena/gena_device.c
@@ -1215,10 +1215,32 @@ static int create_url_list(
 }
 
 /*!
+ * \brief Return 1 if addr is an RFC 1918 private address, 0 otherwise.
+ */
+static int is_rfc1918_addr(struct in_addr addr)
+{
+	uint32_t a = ntohl(addr.s_addr);
+	/* 10.0.0.0/8 */
+	if ((a & 0xFF000000u) == 0x0A000000u)
+		return 1;
+	/* 172.16.0.0/12 */
+	if ((a & 0xFFF00000u) == 0xAC100000u)
+		return 1;
+	/* 192.168.0.0/16 */
+	if ((a & 0xFFFF0000u) == 0xC0A80000u)
+		return 1;
+	return 0;
+}
+
+/*!
  * \brief Validate that the URLs passed by the user are on the same network
  * segment than the device.
  *
  * Note: This is a fix for CallStanger a.k.a. CVE-2020-12695
+ *
+ * For private networks (RFC 1918) the UPnP spec requires that the delivery
+ * URL is within any RFC 1918 range, not necessarily the same subnet.
+ * Strict same-subnet checking is kept for non-private device addresses.
  *
  * \return 0 if all URLs are on the same segment or -1 otherwise.
  */
@@ -1257,6 +1279,13 @@ int gena_validate_delivery_urls(
 			deliveryAddr4 =
 				(struct sockaddr_in *)&url_list->parsedURLs[i]
 					.hostport.IPaddress;
+			/* For RFC 1918 private networks the UPnP spec requires
+			 * the delivery URL to be in any private range, not
+			 * necessarily the same subnet (issue #379). */
+			if (is_rfc1918_addr(genaAddr4) &&
+				is_rfc1918_addr(deliveryAddr4->sin_addr)) {
+				continue;
+			}
 			if ((deliveryAddr4->sin_addr.s_addr &
 				    genaNetmask.s_addr) !=
 				(genaAddr4.s_addr & genaNetmask.s_addr)) {


### PR DESCRIPTION
## Summary

Fixes #379.

The CallStranger fix (PR #181) introduced a strict same-subnet check for GENA
delivery URLs. In a multicast-routed environment a UPnP device (e.g.
192.168.10.34/24) and a subscriber (e.g. 192.168.27.65/24) can be on different
/24 subnets while both remaining within the RFC 1918 private address space.
The strict check rejects such subscriptions with HTTP 412.

The UPnP spec states: *"For private networks this means that the delivery URL
provided will adhere to the following IP ranges: 10/8, 172.16/12, 192.168/16."*
The intent is to prevent SSRF to public internet addresses, not to require
identical subnets.

## Changes

- `upnp/src/gena/gena_device.c`: add `is_rfc1918_addr()` helper; in
  `gena_validate_delivery_urls()` short-circuit the subnet check when both the
  device address and the delivery URL are RFC 1918 private. The strict subnet
  check is preserved for non-private device addresses.
- `gtest/test_gena.cpp`: new regression test suite covering same-subnet,
  cross-subnet same RFC 1918 class, cross-RFC 1918 class, and public URL cases.
- `gtest/CMakeLists.txt`: register `test_gena-static` target.

## Test plan

- [ ] `test_gena-static` passes (4/4): same-subnet accepted, cross-subnet
  192.168.10.x ↔ 192.168.27.x accepted, 10/8 device ↔ 192.168/16 delivery
  accepted, public delivery URL rejected.
- [ ] No regressions in the existing test suite.