### PR TITLE
fix: prevent dangling pointer in CIfaddr4::set() by storing ifname as member

### DIFF
--- a/gtest/tools/tools.cpp
+++ b/gtest/tools/tools.cpp
@@ -17,6 +17,7 @@ class CIfaddr4
 	struct sockaddr_in ifa_netmask;	// netmask
 	struct sockaddr_in ifa_ifu;		// broadcast addr or point-to-point dest addr
 	struct ifaddrs ifaddr;
+	std::string m_ifname;
 
 	// the bitmask is the offset in the netmasks array.
 	std::string netmasks[33] = {"0.0.0.0",
@@ -72,7 +73,8 @@ public:
 	// set to an ipv4 UP interface, supporting broadcast and multicast.
 	// Returns true if successful.
 	{
-		ifaddr.ifa_name = (char*)pIfname.c_str();
+		m_ifname = pIfname;
+		ifaddr.ifa_name = (char*)m_ifname.c_str();
 
 		// get the netmask from the bitmask
 		// the bitmask is the offset in the netmasks array.


### PR DESCRIPTION
## Summary

- `CIfaddr4::set()` took `pIfname` by value and assigned `pIfname.c_str()` directly to `ifaddr.ifa_name`. The `std::string` was destroyed on return, leaving a dangling pointer.
- When `UpnpGetIfInfo` subsequently read `ifa->ifa_name`, AddressSanitizer reported a **stack-use-after-scope**, causing `test-upnp-Issue195TestSuite.GetIfInfo_clears_stale_IPv6_when_interface_has_none` (static variant) to fail.
- Fix: store the interface name in a `std::string m_ifname` member of `CIfaddr4`; its lifetime matches the object, so `ifa_name` always points to valid memory.

## Test plan

- [ ] `ctest --output-on-failure --timeout 5` — all 59 tests pass (was 98%, 1 failed before fix)
- [ ] Specifically `test-upnp-Issue195TestSuite.GetIfInfo_clears_stale_IPv6_when_interface_has_none-static` now passes under ASan