### PR TITLE
fix: bind SSDP sockets to selected interface address (issue #227)

### DIFF
--- a/upnp/src/ssdp/ssdp_server.c
+++ b/upnp/src/ssdp/ssdp_server.c
@@ -968,7 +968,7 @@ static int create_ssdp_sock_v4(
 	#endif /* BSD, __APPLE__ */
 	memset(&__ss, 0, sizeof(__ss));
 	ssdpAddr4->sin_family = (sa_family_t)AF_INET;
-	ssdpAddr4->sin_addr.s_addr = htonl(INADDR_ANY);
+	inet_pton(AF_INET, gIF_IPV4, &ssdpAddr4->sin_addr);
 	ssdpAddr4->sin_port = htons(SSDP_PORT);
 	ret = bind(*ssdpSock, (struct sockaddr *)ssdpAddr4, sizeof(*ssdpAddr4));
 	if (ret == -1) {
@@ -977,8 +977,8 @@ static int create_ssdp_sock_v4(
 			SSDP,
 			__FILE__,
 			__LINE__,
-			"Error in bind(), addr=0x%08X, port=%d: %s\n",
-			INADDR_ANY,
+			"Error in bind(), addr=%s, port=%d: %s\n",
+			gIF_IPV4,
 			SSDP_PORT,
 			errorBuffer);
 		ret = UPNP_E_SOCKET_BIND;
@@ -1186,7 +1186,7 @@ static int create_ssdp_sock_v6(
 	}
 	memset(&__ss, 0, sizeof(__ss));
 	ssdpAddr6->sin6_family = (sa_family_t)AF_INET6;
-	ssdpAddr6->sin6_addr = in6addr_any;
+	inet_pton(AF_INET6, gIF_IPV6, &ssdpAddr6->sin6_addr);
 		#ifndef _WIN32
 	ssdpAddr6->sin6_scope_id = gIF_INDEX;
 		#endif
@@ -1366,7 +1366,7 @@ static int create_ssdp_sock_v6_ula_gua(
 	}
 	memset(&__ss, 0, sizeof(__ss));
 	ssdpAddr6->sin6_family = (sa_family_t)AF_INET6;
-	ssdpAddr6->sin6_addr = in6addr_any;
+	inet_pton(AF_INET6, gIF_IPV6_ULA_GUA, &ssdpAddr6->sin6_addr);
 	ssdpAddr6->sin6_scope_id = gIF_INDEX;
 	ssdpAddr6->sin6_port = htons(SSDP_PORT);
 	ret = bind(*ssdpSock, (struct sockaddr *)ssdpAddr6, sizeof(*ssdpAddr6));
@@ -1376,8 +1376,8 @@ static int create_ssdp_sock_v6_ula_gua(
 			SSDP,
 			__FILE__,
 			__LINE__,
-			"Error in bind(), addr=0x%032lX, port=%d: %s\n",
-			0lu,
+			"Error in bind(), addr=%s, port=%d: %s\n",
+			gIF_IPV6_ULA_GUA,
 			SSDP_PORT,
 			errorBuffer);
 		ret = UPNP_E_SOCKET_BIND;

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -57,6 +57,18 @@ if(UPNP_BUILD_STATIC)
 	add_test(NAME test-upnp-threadpool-overflow-static
 		COMMAND test-upnp-threadpool-overflow-static)
 endif()
+# Issue #227: SSDP server socket must bind to the selected interface address,
+# not to INADDR_ANY.  Uses /proc/net/udp to verify; skipped on non-Linux.
+UPNP_Add_Unit_Test(test-upnp-ssdp-bind-specific test_ssdp_bind_specific.c)
+if(UPNP_BUILD_SHARED)
+	set_tests_properties(test-upnp-ssdp-bind-specific
+		PROPERTIES SKIP_RETURN_CODE 77)
+endif()
+if(UPNP_BUILD_STATIC)
+	set_tests_properties(test-upnp-ssdp-bind-specific-static
+		PROPERTIES SKIP_RETURN_CODE 77)
+endif()
+
 UPNP_Add_Unit_Test(test-upnp-gena-subscribe-dos test_gena_subscribe_dos.c)
 UPNP_Add_Unit_Test(test-upnp-gena-subscribe-pressure test_gena_subscribe_pressure.c)
 # Both GENA issue-#435 tests read constants from config.h (a private header).

--- a/upnp/test/test_ssdp_bind_specific.c
+++ b/upnp/test/test_ssdp_bind_specific.c
@@ -1,0 +1,210 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*- */
+/**************************************************************************
+ *
+ * Copyright (c) 2026 The pupnp contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************/
+
+/*!
+ * \file
+ * \brief Regression test for issue #227: SSDP server must bind to the
+ * selected interface address, not to INADDR_ANY (0.0.0.0).
+ *
+ * Strategy (Linux only):
+ *   1. Call UpnpInit2() and note the assigned IPv4 server address via
+ *      UpnpGetServerIpAddress().
+ *   2. Enumerate this process's open socket file-descriptors via
+ *      /proc/self/fd to collect their inodes.
+ *   3. Scan /proc/net/udp for any entry whose inode belongs to this
+ *      process and whose port is 1900 (SSDP_PORT).
+ *   4. FAIL if any such entry shows a local address of 00000000
+ *      (INADDR_ANY); PASS otherwise.
+ *
+ * Skipped on non-Linux platforms where /proc/net/udp is absent.
+ */
+
+#include "upnp.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef _WIN32
+	#include <arpa/inet.h>
+	#include <dirent.h>
+	#include <string.h>
+	#include <sys/stat.h>
+	#include <unistd.h>
+#endif
+
+#ifndef _WIN32
+
+	#define MAX_SOCKETS 256
+
+/* regression: issue #227 */
+
+static int collect_own_socket_inodes(unsigned long *inodes, int max)
+{
+	DIR *dir = opendir("/proc/self/fd");
+	if (!dir)
+		return 0;
+
+	int n = 0;
+	struct dirent *ent;
+	while ((ent = readdir(dir)) != NULL && n < max) {
+		char path[64];
+		snprintf(path, sizeof(path), "/proc/self/fd/%s", ent->d_name);
+		struct stat st;
+		if (stat(path, &st) == 0 && S_ISSOCK(st.st_mode))
+			inodes[n++] = (unsigned long)st.st_ino;
+	}
+	closedir(dir);
+	return n;
+}
+
+static int inode_in_list(
+	unsigned long inode, const unsigned long *list, int list_len)
+{
+	for (int i = 0; i < list_len; i++)
+		if (list[i] == inode)
+			return 1;
+	return 0;
+}
+
+/*
+ * Returns  0 : checked OK (no INADDR_ANY SSDP socket belonging to us)
+ * Returns -1 : FAIL (found at least one INADDR_ANY SSDP socket of ours)
+ * Returns  1 : SKIP (no matching socket found or /proc not available)
+ */
+static int check_ssdp_v4_bound_to_specific(void)
+{
+	unsigned long our_inodes[MAX_SOCKETS];
+	int n_inodes = collect_own_socket_inodes(our_inodes, MAX_SOCKETS);
+	if (n_inodes == 0) {
+		printf("SKIP (/proc/self/fd not available or no sockets "
+		       "open)\n");
+		return 1;
+	}
+
+	FILE *f = fopen("/proc/net/udp", "r");
+	if (!f) {
+		printf("SKIP (/proc/net/udp not available on this platform)\n");
+		return 1;
+	}
+
+	char line[256];
+	fgets(line, sizeof(line), f); /* skip header */
+
+	int found = 0;
+	int result = 1; /* default: skip (no matching socket seen) */
+	while (fgets(line, sizeof(line), f)) {
+		char local_addr[9] = {0};
+		unsigned local_port = 0;
+		unsigned long inode = 0;
+		char sl[8];
+		/*
+		 * /proc/net/udp columns:
+		 * sl  local_addr:port  rem_addr:port  st  tx:rx  tr:tm
+		 *   retrnsmt  uid  timeout  inode  ...
+		 */
+		char rem[20], st_s[4], txrx[20], trtm[20];
+		unsigned retrnsmt, uid, timeout;
+		if (sscanf(line,
+			    " %7s %8[^:]:%4X %19s %3s %19s %19s %u %u %u %lu",
+			    sl,
+			    local_addr,
+			    &local_port,
+			    rem,
+			    st_s,
+			    txrx,
+			    trtm,
+			    &retrnsmt,
+			    &uid,
+			    &timeout,
+			    &inode) < 11)
+			continue;
+
+		if (local_port != 0x076C) /* 1900 decimal */
+			continue;
+
+		if (!inode_in_list(inode, our_inodes, n_inodes))
+			continue;
+
+		found = 1;
+		if (strcmp(local_addr, "00000000") == 0) {
+			printf("FAIL: our SSDP IPv4 socket (inode %lu) is "
+			       "bound "
+			       "to INADDR_ANY; should be bound to %s\n",
+				inode,
+				UpnpGetServerIpAddress());
+			fclose(f);
+			return -1;
+		}
+		printf("OK: our SSDP IPv4 socket (inode %lu) is bound to "
+		       "%s (not INADDR_ANY)\n",
+			inode,
+			local_addr);
+		result = 0;
+	}
+	fclose(f);
+
+	if (!found)
+		printf("SKIP (no SSDP socket belonging to this process found "
+		       "in /proc/net/udp)\n");
+
+	return result;
+}
+
+int main(void)
+{
+	int rc = UpnpInit2(NULL, 0);
+	if (rc != UPNP_E_SUCCESS) {
+		printf("SKIP (UpnpInit2 returned %d — no suitable interface)\n",
+			rc);
+		exit(77); /* automake SKIP exit code */
+	}
+
+	printf("Server IPv4 address: %s\n", UpnpGetServerIpAddress());
+
+	int result = check_ssdp_v4_bound_to_specific();
+
+	UpnpFinish();
+
+	if (result < 0)
+		exit(EXIT_FAILURE);
+
+	printf("test_ssdp_bind_specific: PASS\n");
+	exit(EXIT_SUCCESS);
+}
+
+#else /* _WIN32 */
+
+int main(void)
+{
+	printf("test_ssdp_bind_specific: SKIP (Linux /proc interface not "
+	       "available on Windows)\n");
+	exit(77);
+}
+
+#endif /* _WIN32 */


### PR DESCRIPTION
Fixes #227

## What

`create_ssdp_sock_v4()`, `create_ssdp_sock_v6()`, and
`create_ssdp_sock_v6_ula_gua()` were binding to `INADDR_ANY` /
`in6addr_any` despite `gIF_IPV4` / `gIF_IPV6` / `gIF_IPV6_ULA_GUA`
already being available. On a multi-homed host this caused the SSDP
server to accept traffic on all interfaces, not just the one selected
at `UpnpInit2()` time.

## Fix

Bind to the specific interface address at all three sites. Multicast
delivery is unaffected: the `IP_ADD_MEMBERSHIP` / `IPV6_JOIN_GROUP`
joins already scope multicast reception to the correct interface.

Also updates the `bind()` error log in `create_ssdp_sock_v4()` and
`create_ssdp_sock_v6_ula_gua()` to print the actual address instead of
a hardcoded `INADDR_ANY` literal.

## POC Tests

`upnp/test/test_ssdp_bind_specific.c` — verifies (on Linux) that after
`UpnpInit2()` the SSDP IPv4 server socket is bound to the specific
interface address, not `INADDR_ANY`. Uses `/proc/self/fd` inode
cross-referencing against `/proc/net/udp` to identify the library's
own socket. Skipped on non-Linux platforms.

## Checklist
- [x] Fix implemented
- [x] POC test fails on unfixed code, passes on fixed code (TDD confirmed locally)
- [x] No regressions in existing test suite
- [x] clang-format clean
- [x] CI green