### PR TITLE
fix: suppress CodeQL non-https-url alerts (security alerts #8, #9, #10, #26, #27)

### DIFF
--- a/samples/tv/common/tv_device.c
+++ b/samples/tv/common/tv_device.c
@@ -1468,7 +1468,7 @@ int TvDeviceStart(char *iface,
 	case AF_INET:
 		snprintf(desc_doc_url,
 			DESC_URL_SIZE,
-			"http://%s:%d/%s",
+			"http://%s:%d/%s", /* lgtm[cpp/non-https-url] */
 			ip_address,
 			port,
 			desc_doc_name);
@@ -1476,7 +1476,7 @@ int TvDeviceStart(char *iface,
 	case AF_INET6:
 		snprintf(desc_doc_url,
 			DESC_URL_SIZE,
-			"http://[%s]:%d/%s",
+			"http://[%s]:%d/%s", /* lgtm[cpp/non-https-url] */
 			ip_address,
 			port,
 			desc_doc_name);

--- a/upnp/src/urlconfig/urlconfig.c
+++ b/upnp/src/urlconfig/urlconfig.c
@@ -187,7 +187,7 @@ static UPNP_INLINE int calc_descURL(
 	const char *ipPortStr, const char *alias, char descURL[LINE_SIZE])
 {
 	size_t len;
-	const char *http_scheme = "http://";
+	const char *http_scheme = "http://"; /* lgtm[cpp/non-https-url] */
 
 	assert(ipPortStr != NULL && strlen(ipPortStr) > 0);
 	assert(alias != NULL && strlen(alias) > 0);


### PR DESCRIPTION
## Summary

- Add `lgtm[cpp/non-https-url]` suppression comments to `samples/tv/common/tv_device.c` (IPv4 and IPv6 URL format strings in `TvDeviceStart`) and `upnp/src/urlconfig/urlconfig.c` (`http_scheme` in `calc_descURL`).
- Dismiss all five CodeQL alerts (#8, #9, #10, #26, #27) as "won't fix" on GitHub with explanations.

## Rationale

UPnP uses HTTP by design for device description URLs served by the miniserver on the local network. Changing these to HTTPS would:
- Break compliance with the UPnP Device Architecture specification.
- Require certificate management in sample code.
- Break interoperability with standard UPnP control points.

The `lgtm[cpp/non-https-url]` suppression prevents CodeQL from re-opening these alerts if the files are re-scanned.

## Test plan

- [x] `samples/tv/common/tv_device.c` (`tv_device` binary) builds cleanly.
- [x] `upnp/src/urlconfig/urlconfig.c` (`upnp_shared` library) builds cleanly.