### PR TITLE
fix: crash in alias_release() when UpnpFinish() races web_server_destroy() (fixes #325)

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -43,6 +43,11 @@ env:
     -DCMAKE_CXX_FLAGS="-fsanitize=address,leak" \
     -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,leak"
 
+  cmake_tsan_flags: |-
+    -DCMAKE_C_FLAGS="-fsanitize=thread" \
+    -DCMAKE_CXX_FLAGS="-fsanitize=thread" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=thread"
+
   ctest_flags: |-
     --test-dir build \
     --output-on-failure \
@@ -253,3 +258,28 @@ jobs:
       - name: ctest (cmake)
         if: ${{ matrix.tool == 'cmake' }}
         run: ctest ${{ env.ctest_flags }}
+  # Linux TSan build (cmake only — TSan is incompatible with ASan/LSan)
+  build_tsan:
+    name: TSan build (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Python test dependencies
+        run: pip install pytest
+      - name: configure
+        run: |
+          cmake \
+            ${{ env.cmake_common_flags }} \
+            -DCMAKE_BUILD_TYPE=Debug \
+            ${{ env.cmake_tsan_flags }}
+      - name: build
+        run: cmake --build build
+      - name: ctest
+        # libtsan.so needs TLS slots that Python exhausts before dlopen();
+        # preloading it at process start avoids the "static TLS block" error
+        # in the Python ctypes tests.
+        run: |
+          LD_PRELOAD=$(gcc -print-file-name=libtsan.so) \
+          ctest ${{ env.ctest_flags }}
+        env:
+          TSAN_OPTIONS: halt_on_error=1

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -737,9 +737,6 @@ int UpnpFinish(void)
 #if EXCLUDE_MINISERVER == 0
 	StopMiniServer();
 #endif
-#if EXCLUDE_WEB_SERVER == 0
-	web_server_destroy();
-#endif
 	ThreadPoolShutdown(&gMiniServerThreadPool);
 	PrintThreadPoolStats(&gMiniServerThreadPool,
 		__FILE__,
@@ -751,6 +748,9 @@ int UpnpFinish(void)
 	ThreadPoolShutdown(&gSendThreadPool);
 	PrintThreadPoolStats(
 		&gRecvThreadPool, __FILE__, __LINE__, "Recv Thread Pool");
+#if EXCLUDE_WEB_SERVER == 0
+	web_server_destroy();
+#endif
 #ifdef INCLUDE_CLIENT_APIS
 	ithread_mutex_destroy(&GlobalClientSubscribeMutex);
 #endif

--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -98,10 +98,15 @@ typedef enum
 /*! . */
 static uint16_t miniStopSockPort;
 
-/*!
- * module vars
- */
+	/*!
+	 * module vars
+	 */
+	/* MSVC does not implement the C11 _Atomic qualifier. */
+	#ifdef _MSC_VER
 static MiniServerState gMServState = MSERV_IDLE;
+	#else
+static _Atomic MiniServerState gMServState = MSERV_IDLE;
+	#endif
 
 /*! Global list to track active socket connections */
 static LinkedList gActiveConnections;

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -226,6 +226,26 @@ endif()
 # in the test file avoid pulling in the internal header chain).
 UPNP_Add_Unit_Test(test-upnp-gh-153 poc_gh_153.c)
 
+# Issue #325: crash in alias_release() when UpnpFinish() destroys gWebMutex
+# while a thread pool thread still holds or waits on it.  Detected by TSan.
+# Uses the same web_server_ut_* hooks and requires Threads::Threads because
+# the test spawns a background thread with pthread_create.
+UPNP_Add_Unit_Test(test-upnp-gh-325 poc_gh_325.c)
+if(UPNP_BUILD_SHARED)
+	target_link_libraries(test-upnp-gh-325 PRIVATE
+		Threads::Threads
+		$<$<BOOL:${SOCKET_LIBRARY}>:${SOCKET_LIBRARY}>
+		$<$<BOOL:${NSL_LIBRARY}>:${NSL_LIBRARY}>
+	)
+endif()
+if(UPNP_BUILD_STATIC)
+	target_link_libraries(test-upnp-gh-325-static PRIVATE
+		Threads::Threads
+		$<$<BOOL:${SOCKET_LIBRARY}>:${SOCKET_LIBRARY}>
+		$<$<BOOL:${NSL_LIBRARY}>:${NSL_LIBRARY}>
+	)
+endif()
+
 # Issue #347: HTTP response headers must use title-case names.
 # Starts the UPnP HTTP server via UpnpInit2, sends a GET request over a raw
 # TCP socket, and verifies title-case header names in the response.

--- a/upnp/test/poc_gh_325.c
+++ b/upnp/test/poc_gh_325.c
@@ -1,0 +1,134 @@
+/* poc_gh_325.c
+ *
+ * Regression test for issue #325: crash in alias_release() when UpnpFinish()
+ * destroys gWebMutex while a thread pool thread still holds or waits on it.
+ *
+ * Sends repeated HTTP GET requests to the alias URL while calling UpnpFinish().
+ * Each request dispatches a thread pool thread through web_server_callback()
+ * which calls alias_grab() / alias_release(), exercising gWebMutex.
+ *
+ * Pre-fix: web_server_destroy() fires before ThreadPoolShutdown() drains those
+ *          handler threads → assertion failure / mutex use-after-destroy.
+ * Post-fix: ThreadPoolShutdown() completes first → all handler threads have
+ *           exited → web_server_destroy() fires safely → no crash.
+ *
+ * Run with TSan (-fsanitize=thread) for reliable race detection.
+ * regression: issue #325
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef _WIN32
+
+	#include "upnp.h"
+
+	#include <arpa/inet.h>
+	#include <netinet/in.h>
+	#include <pthread.h>
+	#include <stddef.h>
+	#include <string.h>
+	#include <sys/socket.h>
+	#include <unistd.h>
+
+/* regression: issue #325 -- test hook exported from libupnp */
+extern int web_server_ut_set_alias(
+	const char *name, const char *content, size_t len);
+
+	#ifndef MSG_NOSIGNAL
+		#define MSG_NOSIGNAL 0
+	#endif
+
+static _Atomic int g_keep_requesting = 1;
+static unsigned short g_port;
+
+static void send_one_request(void)
+{
+	int sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0)
+		return;
+
+	struct sockaddr_in addr;
+	memset(&addr, 0, sizeof addr);
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(g_port);
+	inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+
+	if (connect(sock, (struct sockaddr *)&addr, sizeof addr) == 0) {
+		const char *req = "GET /desc.xml HTTP/1.1\r\n"
+				  "Host: localhost\r\n"
+				  "Connection: close\r\n\r\n";
+		send(sock, req, strlen(req), MSG_NOSIGNAL);
+		char buf[256];
+		while (recv(sock, buf, sizeof buf, 0) > 0)
+			;
+	}
+	close(sock);
+}
+
+static void *request_thread(void *arg)
+{
+	(void)arg;
+	while (g_keep_requesting)
+		send_one_request();
+	return NULL;
+}
+
+int main(void)
+{
+	int rc;
+	pthread_t thr;
+
+	rc = UpnpInit2(NULL, 0);
+	if (rc != UPNP_E_SUCCESS) {
+		fprintf(stderr,
+			"UpnpInit2 failed (%d); skipping (no network?)\n",
+			rc);
+		return EXIT_SUCCESS;
+	}
+
+	rc = web_server_ut_set_alias("/desc.xml", "<root/>", 7);
+	if (rc != UPNP_E_SUCCESS) {
+		fprintf(stderr, "web_server_ut_set_alias failed (%d)\n", rc);
+		UpnpFinish();
+		return EXIT_FAILURE;
+	}
+
+	g_port = UpnpGetServerPort();
+	if (g_port == 0) {
+		fprintf(stderr, "UpnpGetServerPort returned 0; skipping\n");
+		UpnpFinish();
+		return EXIT_SUCCESS;
+	}
+
+	if (pthread_create(&thr, NULL, request_thread, NULL) != 0) {
+		fprintf(stderr, "pthread_create failed\n");
+		UpnpFinish();
+		return EXIT_FAILURE;
+	}
+
+	/* Let HTTP requests flow long enough to have handler threads active
+	 * in alias_grab() / alias_release() when UpnpFinish() fires. */
+	usleep(10000); /* 10 ms */
+
+	/* Pre-fix: web_server_destroy() fires before ThreadPoolShutdown()
+	 * drains the handler threads → crash.
+	 * Post-fix: ThreadPoolShutdown() completes first → safe shutdown. */
+	UpnpFinish();
+
+	g_keep_requesting = 0;
+	pthread_join(thr, NULL);
+
+	puts("PASS: no crash detected.");
+	return EXIT_SUCCESS;
+}
+
+#else /* _WIN32 */
+
+int main(void)
+{
+	puts("SKIP: test uses POSIX sockets (not available on Windows).");
+	return EXIT_SUCCESS;
+}
+
+#endif /* _WIN32 */


### PR DESCRIPTION
Fixes #325

## What

`UpnpFinish()` called `web_server_destroy()` before draining the thread
pools. HTTP handler threads dispatched through `web_server_callback()`
call `alias_grab()` / `alias_release()`, which lock `gWebMutex`.
Destroying `gWebMutex` while those threads are still active causes an
assertion failure or use-after-destroy.

A second pre-existing issue: `gMServState` in `miniserver.c` was a plain
`static` variable accessed by `RunMiniServer` (a thread pool thread) and
by `StartMiniServer` / `StopMiniServer` (caller threads) without a common
lock — a data race flagged by TSan.

## Commits

1. **fix: move `web_server_destroy()` after `ThreadPoolShutdown()`** —
   ensures all in-flight HTTP handlers have exited before the web server
   state is torn down.

2. **fix: make `gMServState` `_Atomic`** — eliminates the pre-existing
   data races on the miniserver state variable; all existing usages are
   simple stores and loads compatible with `_Atomic` without further
   changes.

3. **test: regression test + TSan CI job** — `poc_gh_325.c` fires
   repeated HTTP GET requests to the alias URL while `UpnpFinish()` runs,
   exercising the real thread pool path. A new `build_tsan` CI job
   (`-fsanitize=thread`, cmake/Debug, ubuntu-latest) catches thread races
   automatically going forward.

## Test plan

- [ ] `ctest --test-dir build -R "test-upnp-gh-325$" --output-on-failure`
- [ ] Full suite clean under TSan:
  `LD_PRELOAD=$(gcc -print-file-name=libtsan.so) TSAN_OPTIONS=halt_on_error=1 ctest --test-dir build --output-on-failure`
- [ ] No regressions in regular build: `ctest --test-dir build --output-on-failure`
- [ ] CI green (including new `build_tsan` job)