### PR TITLE
fix: remove UpnpPrintf from public API (fixes #365)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,11 +23,20 @@ dnl #
 dnl # *please update only once, before a formal release, not for each change*
 dnl #
 dnl ############################################################################
-AC_INIT([libupnp],[1.20.0],[mroberto@users.sourceforge.net])
+AC_INIT([libupnp],[2.0.0],[mroberto@users.sourceforge.net])
 AC_SUBST([LT_VERSION_IXML], [12:8:1])
-AC_SUBST([LT_VERSION_UPNP], [21:0:1])
+AC_SUBST([LT_VERSION_UPNP], [22:0:0])
 dnl ############################################################################
-dnl # Release 1.20.0 (next)
+dnl # Release 2.0.0 (next)
+dnl # "current:revision:age"
+dnl #
+dnl # - Interface removed: UpnpPrintf removed from public API (issue #365)
+dnl #   current: 21 -> 22
+dnl #   revision: 0
+dnl #   age: 1 -> 0  (interface removed, not backward compatible)
+dnl #
+dnl ############################################################################
+dnl # Release 1.20.0
 dnl # "current:revision:age"
 dnl #
 dnl # - Interfaces added in upnp: UpnpGetSsdpReqPort4, UpnpGetSsdpReqPort6

--- a/upnp/Makefile.am
+++ b/upnp/Makefile.am
@@ -206,8 +206,13 @@ test_list_SOURCES = test/test_list.c
 test_parse_uri_SOURCES = test/test_parse_uri.c test/test_parse_uri_impl.c
 test_parse_uri_LDADD = $(LDADD)
 
+# Issue #365: UpnpPrintf must not be a public DSO symbol.  The script exits
+# 77 (automake SKIP) when nm is unavailable or on non-ELF platforms.
+TESTS += test/check_symbol_visibility.sh
+
 EXTRA_DIST = \
 	m4/libupnp.m4 \
-	src/win_dll.c
+	src/win_dll.c \
+	test/check_symbol_visibility.sh
 
 CLEANFILES = libupnp_err.log libupnp_info.log

--- a/upnp/inc/upnpdebug.h
+++ b/upnp/inc/upnpdebug.h
@@ -187,60 +187,9 @@ static UPNP_INLINE FILE *UpnpGetDebugFile_Inlined(
 }
 #endif
 
-/*!
- * \brief Prints the debug statement either on the standard output or log file
- * along with the information from where this debug statement is coming.
- */
-void UpnpPrintf(
-	/*! [in] The level of the debug logging. It will decide whether debug
-	 * statement will go to standard output, or any of the log files. */
-	Upnp_LogLevel DLevel,
-	/*! [in] debug will go in the name of this module. */
-	Dbg_Module Module,
-	/*! [in] Name of the file from where debug statement is coming. */
-	const char *DbgFileName,
-	/*! [in] Line number of the file from where debug statement is coming.
-	 */
-	int DbgLineNo,
-	/*! [in] Printf like format specification. */
-	const char *FmtStr,
-	/*! [in] Printf like Variable number of arguments that will go in the
-	 * debug statement. */
-	...)
-#if (__GNUC__ >= 3)
-	/* This enables printf like format checking by the compiler. */
-	__attribute__((format(__printf__, 5, 6)))
-#endif
-	;
-
-#if defined NDEBUG && !defined UPNP_DEBUG_C
-	#define UpnpPrintf UpnpPrintf_Inlined
-// static UPNP_INLINE void UpnpPrintf_Inlined(Upnp_LogLevel DLevel,
-// 	Dbg_Module Module,
-// 	const char *DbgFileName,
-// 	int DbgLineNo,
-// 	const char *FmtStr,
-// 	...)
-// #if (__GNUC__ >= 3)
-// 	/* This enables printf like format checking by the compiler. */
-// 	__attribute__((format(__printf__, 5, 6)))
-// #endif
-// 	;
-static UPNP_INLINE void UpnpPrintf_Inlined(Upnp_LogLevel DLevel,
-	Dbg_Module Module,
-	const char *DbgFileName,
-	int DbgLineNo,
-	const char *FmtStr,
-	...)
-{
-	(void)DLevel;
-	(void)Module;
-	(void)DbgFileName;
-	(void)DbgLineNo;
-	(void)FmtStr;
-	return;
-}
-#endif /* DEBUG */
+/* UpnpPrintf is an internal function removed from the public API (issue #365).
+ * Library-internal callers: include upnpdebug_internal.h.
+ * External callers: use UpnpGetDebugFile() to obtain the log FILE pointer. */
 
 #ifdef __cplusplus
 }

--- a/upnp/src/api/upnpdebug.c
+++ b/upnp/src/api/upnpdebug.c
@@ -38,6 +38,7 @@
 #include "ithread.h"
 #include "upnp.h"
 #include "upnpdebug.h"
+#include "upnpdebug_internal.h"
 
 #include <errno.h>
 #include <stdarg.h>
@@ -256,6 +257,9 @@ static void UpnpDisplayFileAndLine(FILE *fp,
 	fflush(fp);
 }
 
+#if defined(__GNUC__) && __GNUC__ >= 4
+__attribute__((visibility("hidden")))
+#endif
 void UpnpPrintf(Upnp_LogLevel DLevel,
 	Dbg_Module Module,
 	const char *DbgFileName,

--- a/upnp/src/gena/gena_callback2.c
+++ b/upnp/src/gena/gena_callback2.c
@@ -38,7 +38,7 @@
 	#include "httpparser.h"
 	#include "httpreadwrite.h"
 	#include "statcodes.h"
-	#include "upnpdebug.h"
+	#include "upnpdebug_internal.h"
 
 /************************************************************************
  * Function : error_respond

--- a/upnp/src/genlib/net/http/httpparser.c
+++ b/upnp/src/genlib/net/http/httpparser.c
@@ -45,7 +45,7 @@
 #include "httpparser.h"
 #include "statcodes.h"
 #include "strintmap.h"
-#include "upnpdebug.h"
+#include "upnpdebug_internal.h"
 
 #include <assert.h>
 #include <ctype.h>

--- a/upnp/src/genlib/net/sock.c
+++ b/upnp/src/genlib/net/sock.c
@@ -45,7 +45,7 @@
 #include "UpnpStdInt.h" /* ssize_t on MSVC */ // IWYU pragma: keep
 #include "upnp.h"
 
-#include "upnpdebug.h"
+#include "upnpdebug_internal.h"
 #include "upnputil.h"
 
 #include <assert.h>

--- a/upnp/src/inc/service_table.h
+++ b/upnp/src/inc/service_table.h
@@ -45,7 +45,7 @@ extern "C" {
 #include "config.h"
 #include "ixml.h"
 #include "upnp.h"
-#include "upnpdebug.h"
+#include "upnpdebug_internal.h"
 #include "uri.h"
 
 #include <time.h>

--- a/upnp/src/inc/upnpdebug_internal.h
+++ b/upnp/src/inc/upnpdebug_internal.h
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2000-2003 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither name of Intel Corporation nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#ifndef UPNP_DEBUG_INTERNAL_H
+#define UPNP_DEBUG_INTERNAL_H
+
+/*!
+ * \file
+ * Internal declaration of UpnpPrintf.  Include this header (not upnpdebug.h)
+ * from library-internal translation units that call UpnpPrintf directly.
+ * External callers must use UpnpGetDebugFile() from the public upnpdebug.h.
+ */
+
+#include "upnpdebug.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \brief Prints the debug statement either on the standard output or log file
+ * along with the information from where this debug statement is coming.
+ *
+ * This function is internal to libupnp and is not part of the public API.
+ */
+void UpnpPrintf(
+	/*! [in] The level of the debug logging. */
+	Upnp_LogLevel DLevel,
+	/*! [in] debug will go in the name of this module. */
+	Dbg_Module Module,
+	/*! [in] Name of the file from where debug statement is coming. */
+	const char *DbgFileName,
+	/*! [in] Line number of the file from where debug statement is coming.
+	 */
+	int DbgLineNo,
+	/*! [in] Printf like format specification. */
+	const char *FmtStr,
+	/*! [in] Printf like Variable number of arguments. */
+	...)
+#if (__GNUC__ >= 3)
+	__attribute__((format(__printf__, 5, 6)))
+#endif
+	;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UPNP_DEBUG_INTERNAL_H */

--- a/upnp/src/urlconfig/urlconfig.c
+++ b/upnp/src/urlconfig/urlconfig.c
@@ -40,7 +40,7 @@
 #include "membuffer.h"
 #include "unixutil.h"
 #include "upnp.h"
-#include "upnpdebug.h"
+#include "upnpdebug_internal.h"
 #include "upnputil.h"
 #include "uri.h"
 #include "urlconfig.h"

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -265,3 +265,21 @@ if(UPNP_BUILD_STATIC)
 		$<$<BOOL:${NSL_LIBRARY}>:${NSL_LIBRARY}>
 	)
 endif()
+
+# Issue #365: UpnpPrintf must not appear in the shared library's public symbol
+# table.  The script exits 77 (skip) when nm is unavailable or on non-ELF
+# platforms (Windows, macOS).
+if(UPNP_BUILD_SHARED)
+	add_test(
+		NAME test-upnp-UpnpPrintf-not-exported
+		COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/check_symbol_visibility.sh
+			$<TARGET_FILE:upnp_shared>
+	)
+	# Clear LD_PRELOAD so the sh subprocess does not inherit TSan's preload library.
+	# TSan CI sets LD_PRELOAD=libtsan.so globally; sh running under TSan with
+	# TSAN_OPTIONS=halt_on_error=1 causes a SEGFAULT before the script can run.
+	set_tests_properties(test-upnp-UpnpPrintf-not-exported
+		PROPERTIES
+			SKIP_RETURN_CODE 77
+			ENVIRONMENT "LD_PRELOAD=")
+endif()

--- a/upnp/test/check_symbol_visibility.sh
+++ b/upnp/test/check_symbol_visibility.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# regression: issue #365 – UpnpPrintf must not appear in the shared-library
+# dynamic symbol table.
+#
+# Background
+# ----------
+# CMake builds compile the library with -fvisibility=hidden, so every symbol
+# is hidden by default; only symbols marked UPNP_EXPORT_SPEC (which expands to
+# __attribute__((visibility("default")))) are exported.  UpnpPrintf has no
+# UPNP_EXPORT_SPEC, so it is already hidden in CMake builds – this test acts
+# as a regression guard there.
+#
+# Autotools builds do NOT set -fvisibility=hidden globally; instead libtool
+# uses -export-symbols-regex '^Upnp.*' to build a linker version script that
+# exports every symbol whose name starts with "Upnp".  UpnpPrintf matches that
+# regex, so without an explicit __attribute__((visibility("hidden"))) on its
+# definition (upnpdebug.c) the symbol leaks into the public DSO interface.
+# This test catches that leak – it is expected to FAIL on unfixed autotools
+# builds and PASS once the visibility attribute is in place.
+#
+# Usage: $0 [<path-to-libupnp.so>]
+#   With argument : CMake passes $<TARGET_FILE:upnp_shared>
+#   No argument   : autotools – the script searches .libs/ relative to the
+#                   upnp/ build directory where make check runs.
+#
+# Exit codes:  0 = PASS  1 = FAIL  77 = SKIP (nm absent / non-ELF platform)
+
+SYMBOL="UpnpPrintf"
+
+# nm -D is only meaningful on ELF platforms
+case "$(uname -s 2>/dev/null)" in
+	Linux | FreeBSD | NetBSD | OpenBSD | SunOS) ;;
+	*)
+		printf 'SKIP: nm -D check only runs on ELF platforms\n'
+		exit 77
+		;;
+esac
+
+if ! command -v nm >/dev/null 2>&1; then
+	printf 'SKIP: nm not available\n'
+	exit 77
+fi
+
+LIB="${1}"
+if [ -z "$LIB" ]; then
+	# Autotools: tests execute from the upnp/ build directory; libtool
+	# places the real .so in the .libs/ subdirectory.
+	for candidate in .libs/libupnp.so .libs/libupnp.so.[0-9]*; do
+		[ -f "$candidate" ] && LIB="$candidate" && break
+	done
+fi
+
+if [ -z "$LIB" ] || [ ! -f "$LIB" ]; then
+	printf 'SKIP: libupnp shared library not found\n'
+	exit 77
+fi
+
+# nm -D lists only dynamic (exported) symbols.
+# T = global text symbol (defined), W = weak global symbol (defined).
+# A match means UpnpPrintf is reachable by DSO clients – which is the bug.
+if nm -D "$LIB" 2>/dev/null | grep -qE " [TW] ${SYMBOL}$"; then
+	printf 'FAIL: %s is exported from %s\n' "$SYMBOL" "$LIB" >&2
+	exit 1
+fi
+
+printf 'PASS: %s is not in the dynamic symbol table of %s\n' "$SYMBOL" "$LIB"
+exit 0

--- a/upnp/test/test_log.c
+++ b/upnp/test/test_log.c
@@ -64,19 +64,18 @@ int main(void)
 #endif /* !NDEBUG */
 
 #ifdef UPNP_HAVE_DEBUG
+	/* UpnpPrintf is an internal (hidden) symbol as of issue #365.
+	 * This block uses only the public UpnpGetDebugFile() API so that the
+	 * test links correctly whether UpnpPrintf is exported or not. */
 	int i;
-	FILE *fp;
+	FILE *logfp;
 
 	/* Try a few random calls (let's crash it...) */
 	UpnpCloseLog();
 	UpnpCloseLog();
-	UpnpPrintf(UPNP_CRITICAL,
-		API,
-		__FILE__,
-		__LINE__,
-		"This should not be printed !\n");
-	fp = UpnpGetDebugFile(UPNP_CRITICAL, API);
-	if (fp) {
+	/* Before init: any log-level query must return NULL. */
+	logfp = UpnpGetDebugFile(UPNP_CRITICAL, API);
+	if (logfp) {
 		fprintf(stderr, "Log FP not NULL before init was called !\n");
 		exit(1);
 	}
@@ -86,28 +85,36 @@ int main(void)
 	UpnpSetLogLevel(UPNP_ERROR);
 	UpnpInitLog();
 
-	UpnpPrintf(UPNP_CRITICAL, API, __FILE__, __LINE__, "Hello LOG !\n");
-	UpnpPrintf(UPNP_INFO,
-		API,
-		__FILE__,
-		__LINE__,
-		"This should not be here !\n");
+	logfp = UpnpGetDebugFile(UPNP_CRITICAL, API);
+	if (logfp)
+		fprintf(logfp, "Hello LOG !\n");
+	/* UPNP_INFO must be filtered when the active level is UPNP_ERROR. */
+	if (UpnpGetDebugFile(UPNP_INFO, API)) {
+		fprintf(stderr,
+			"BUG: UPNP_INFO not filtered at UPNP_ERROR level\n");
+		exit(1);
+	}
 
 	/* Let's try to a file */
 	UpnpSetLogFileNames("libupnp_err.log", NULL);
 	UpnpInitLog();
-	UpnpPrintf(UPNP_CRITICAL,
-		API,
-		__FILE__,
-		__LINE__,
-		"Hello from the log file\n");
+	logfp = UpnpGetDebugFile(UPNP_CRITICAL, API);
+	if (logfp)
+		fprintf(logfp, "Hello from the log file\n");
 
 	/* Close and retry stuff */
 	UpnpCloseLog();
-	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Not here either!\n");
+	/* After close, log queries must return NULL again. */
+	logfp = UpnpGetDebugFile(UPNP_CRITICAL, API);
+	if (logfp) {
+		fprintf(stderr, "BUG: log FP not NULL after UpnpCloseLog()\n");
+		exit(1);
+	}
 	UpnpSetLogFileNames(NULL, NULL);
 	UpnpInitLog();
-	UpnpPrintf(UPNP_CRITICAL, API, __FILE__, __LINE__, "I'm back !\n");
+	logfp = UpnpGetDebugFile(UPNP_CRITICAL, API);
+	if (logfp)
+		fprintf(logfp, "I'm back !\n");
 	for (i = 0; i < 10000; i++) {
 		UpnpInitLog();
 		UpnpCloseLog();


### PR DESCRIPTION
Fixes #365

## What

`UpnpPrintf` was declared in the public header `upnp/inc/upnpdebug.h`
without `UPNP_EXPORT_SPEC`, making it part of the visible public API by
name even though it was never intended for external use.

The symbol was already hidden in CMake builds (global `-fvisibility=hidden`),
but autotools exports every symbol matching `-export-symbols-regex '^Upnp.*'`,
so `UpnpPrintf` leaked into the dynamic symbol table on autotools builds.

This is treated as an **API-breaking change** (the symbol was publicly
reachable on autotools builds). The package version is bumped to **2.0.0**
and the libtool interface version to **22:0:0** (`current++`, `age=0` —
interface removed, not backward compatible).

## Changes

- **`configure.ac`** — bump package version `1.20.0` → `2.0.0`; bump
  `LT_VERSION_UPNP` `21:0:1` → `22:0:0`.
- **`upnp/inc/upnpdebug.h`** — remove `UpnpPrintf` declaration; add a
  comment directing internal callers to the new internal header.
- **`upnp/src/inc/upnpdebug_internal.h`** (new) — internal-only declaration
  for library translation units that call `UpnpPrintf` directly.
- **`upnp/src/api/upnpdebug.c`** — add
  `__attribute__((visibility("hidden")))` to the `UpnpPrintf` definition so
  the symbol is hidden even in autotools builds where `-fvisibility=hidden` is
  not set globally; include the new internal header.
- **`upnp/src/inc/service_table.h`** — switch to `upnpdebug_internal.h`;
  this propagates the internal declaration to all sources that include
  `upnpapi.h` transitively.
- **`gena_callback2.c`, `httpparser.c`, `sock.c`, `urlconfig.c`** — switch
  direct `#include "upnpdebug.h"` to `upnpdebug_internal.h`.
- **`upnp/test/test_log.c`** — rewrite the `UPNP_HAVE_DEBUG` block to use
  only the public `UpnpGetDebugFile()` API; `UpnpPrintf` is now hidden in the
  DSO and unreachable from test binaries linked against the shared library.
  The rewrite also adds an explicit level-filtering assertion.
- **`upnp/test/check_symbol_visibility.sh`** (new) — `nm -D` regression test
  confirming `UpnpPrintf` is absent from the dynamic symbol table. Registered
  in both ctest and automake `TESTS`; exits 77 (skip) on non-ELF platforms.

## Verification

```
# CMake — symbol already hidden; test acts as regression guard
nm -D build/upnp/libupnp.so | grep UpnpPrintf   # → empty
ctest --test-dir build --output-on-failure        # → 25/25 passed

# autotools — symbol was exported before this fix
nm -D .libs/libupnp.so | grep UpnpPrintf         # → empty after fix
make check                                        # → 6/6 passed
```

## Checklist
- [x] `UpnpPrintf` absent from `nm -D libupnp.so` on CMake and autotools
- [x] All CMake tests pass (25/25)
- [x] All autotools tests pass (6/6, including new `check_symbol_visibility.sh`)
- [x] clang-format clean
- [x] Version bumped to 2.0.0 (`configure.ac`, `LT_VERSION_UPNP = 22:0:0`)