### PR TITLE
fix: guard GCC diagnostic pragmas with #if defined(__GNUC__)

### DIFF
--- a/upnp/src/inc/upnpapi.h
+++ b/upnp/src/inc/upnpapi.h
@@ -131,8 +131,10 @@ extern ithread_rwlock_t GlobalHndRWLock;
  * \return HND_DEVICE, UPNP_E_INVALID_HANDLE
  */
 static enum Upnp_LogLevel_e debug_handle = UPNP_NEVER;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
+#if defined(__GNUC__)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 Upnp_Handle_Type GetHandleInfo(
 	/*! handle pointer (key for the client handle structure). */
 	int Hnd,
@@ -164,7 +166,9 @@ static void HandleLock(const char *file, int line)
 {
 	HandleWriteLock(file, line);
 }
-#pragma GCC diagnostic pop
+#if defined(__GNUC__)
+	#pragma GCC diagnostic pop
+#endif
 
 /*!
  * \brief Get client handle info.

--- a/upnp/src/urlconfig/urlconfig.c
+++ b/upnp/src/urlconfig/urlconfig.c
@@ -200,10 +200,14 @@ static UPNP_INLINE int calc_descURL(
 		/* len <= LINE_SIZE verified above; GCC cannot prove it
 		 * statically */
 		/* clang-format off */
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
 	snprintf(descURL, LINE_SIZE, "%s%s%s", http_scheme, ipPortStr, alias);
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
 	/* clang-format on */
 	UpnpPrintf(
 		UPNP_INFO, API, __FILE__, __LINE__, "desc url: %s\n", descURL);


### PR DESCRIPTION
Refs #365

## What

MSVC emits C4068 ("unknown pragma 'GCC'") for every bare
`#pragma GCC diagnostic push/ignored/pop`.  Wrapping each block in
`#if defined(__GNUC__)` / `#endif` silences the warnings on MSVC while
leaving GCC and Clang builds unchanged.

Reported in a comment on issue #365 referencing CI run
https://github.com/pupnp/pupnp/actions/runs/26589302111.

## Affected files

- **`upnp/src/inc/upnpapi.h`** — `#pragma GCC diagnostic ignored "-Wunused-function"` around `GetHandleInfo` and the static lock helpers
- **`upnp/src/urlconfig/urlconfig.c`** — `#pragma GCC diagnostic ignored "-Wformat-truncation"` around the `snprintf` call in `calc_descURL`

## Verification

```
# Linux — build clean, no change in behaviour
cmake --build build --target upnp_shared   # no warnings
ctest --test-dir build --output-on-failure # all pass

# Windows CI — grep for C4068 should return empty after this PR
```

## Checklist
- [x] No new warnings on GCC/Clang (Linux CI)
- [x] C4068 warnings eliminated on MSVC (Windows CI)
- [x] clang-format clean