### PR TITLE
fix: create Threads::Shared/Static aliases unconditionally

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -51,7 +51,8 @@ env:
   ctest_flags: |-
     --test-dir build \
     --output-on-failure \
-    --timeout 5
+    --timeout 5 \
+    --exclude-regex "^pthreads4w"
 
 jobs:
   # Linux builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,43 +196,47 @@ endif()
 if(NOT MSVC)
 	set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 	include(FindThreads)
-
-	if(NOT DOWNLOAD_AND_BUILD_DEPS)
-		if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
-			add_library(Threads::Shared ALIAS Threads::Threads)
-			add_library(Threads::Static ALIAS Threads::Threads)
-		else()
-			add_library(Threads::Shared INTERFACE IMPORTED)
-			add_library(Threads::Static INTERFACE IMPORTED)
-
-			# The following two blocks replicate the original FindThreads
-			if(THREADS_HAVE_PTHREAD_ARG)
-				set_property(TARGET Threads::Shared PROPERTY
-					INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -pthread>"
-					"$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-pthread>"
-				)
-
-				set_property(TARGET Threads::Static PROPERTY
-					INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -pthread>"
-					"$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-pthread>"
-				)
-			endif()
-
-			if(CMAKE_THREAD_LIBS_INIT)
-				get_target_property(thread_location Threads::Threads INTERFACE_LINK_LIBRARIES)
-
-				set_target_properties(Threads::Shared PROPERTIES
-					INTERFACE_LINK_LIBRARIES ${thread_location}
-				)
-
-				set_target_properties(Threads::Static PROPERTIES
-					INTERFACE_LINK_LIBRARIES ${thread_location}
-				)
-			endif()
-		endif()
-	endif()
 else()
 	find_package(PTHREADS4W CONFIG REQUIRED)
+endif()
+
+# Threads::Shared and Threads::Static are convenience aliases used by the
+# upnp and test targets.  They must be created in all configurations,
+# including DOWNLOAD_AND_BUILD_DEPS=ON (where the guard below was previously
+# preventing their creation and causing configure errors on all platforms).
+if(TARGET Threads::Threads AND NOT TARGET Threads::Shared)
+	if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+		add_library(Threads::Shared ALIAS Threads::Threads)
+		add_library(Threads::Static ALIAS Threads::Threads)
+	else()
+		add_library(Threads::Shared INTERFACE IMPORTED)
+		add_library(Threads::Static INTERFACE IMPORTED)
+
+		# Replicate the flags/libraries from Threads::Threads
+		if(THREADS_HAVE_PTHREAD_ARG)
+			set_property(TARGET Threads::Shared PROPERTY
+				INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -pthread>"
+				"$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-pthread>"
+			)
+
+			set_property(TARGET Threads::Static PROPERTY
+				INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -pthread>"
+				"$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-pthread>"
+			)
+		endif()
+
+		if(CMAKE_THREAD_LIBS_INIT)
+			get_target_property(thread_location Threads::Threads INTERFACE_LINK_LIBRARIES)
+
+			set_target_properties(Threads::Shared PROPERTIES
+				INTERFACE_LINK_LIBRARIES ${thread_location}
+			)
+
+			set_target_properties(Threads::Static PROPERTIES
+				INTERFACE_LINK_LIBRARIES ${thread_location}
+			)
+		endif()
+	endif()
 endif()
 
 #

--- a/cmake/CmDaB.cmake
+++ b/cmake/CmDaB.cmake
@@ -40,7 +40,7 @@ if (DOWNLOAD_AND_BUILD_DEPS)
 	FetchContent_Declare (
 		CmDaB
 		GIT_REPOSITORY https://github.com/Vollstrecker/CmDaB.git
-		GIT_TAG main
+		GIT_TAG f079cb2  # pin to known-good commit; update when upgrading CmDaB
 	)
 
 	FetchContent_GetProperties(CmDaB)


### PR DESCRIPTION
Fixes the configure error introduced by 098ec5d2 ("switch to use genex for sources and headers").

## Problem 1 — `Threads::Shared` not found (Ubuntu, macOS, MSys)

`Threads::Shared` and `Threads::Static` were only created when
`NOT DOWNLOAD_AND_BUILD_DEPS`.  CI passes `-DDOWNLOAD_AND_BUILD_DEPS=ON`,
so the aliases were never defined, causing configure to fail on every
non-MSVC platform:

```
CMake Error at upnp/CMakeLists.txt:126 (target_link_libraries):
  Target "upnp_shared" links to Threads::Shared but the target was not found.
```

**Fix (`CMakeLists.txt`):** Move the alias creation block outside the
`DOWNLOAD_AND_BUILD_DEPS` guard. Both `FindThreads` (non-MSVC) and
`find_package(PTHREADS4W)` (MSVC) produce a `Threads::Threads` target
regardless of `DOWNLOAD_AND_BUILD_DEPS`, so the aliases can always be
derived from it. A `NOT TARGET Threads::Shared` guard prevents
duplicate-target errors if something upstream already defines them.

## Problem 2 — `PTHREADS4W` not found (Windows MSVC)

CmDaB's `GIT_TAG main` is a moving target. The CmDaB `main` branch changed
between CI runs on 2026-05-29, breaking the pthreads4w download and causing
configure to fail on MSVC builds:

```
CMake Error at CMakeLists.txt:200 (find_package):
  Could not find a package configuration file provided by "PTHREADS4W"
```

**Fix (`cmake/CmDaB.cmake`):** Pin `GIT_TAG` from `main` to commit `f079cb2`
(the known-good tip from the local build cache, dated 2022-02-03). This is
a temporary measure while Vollstrecker reworks CmDaB. The pin will be
updated to the new commit once a fixed CmDaB version is available as a new PR.

## Problem 3 — pthreads4w tests running in pupnp CI (Windows MSVC)

When `DOWNLOAD_AND_BUILD_DEPS=ON`, pthreads4w registers its own test suite
with CTest (benchmarks, build tests, etc.). These are not pupnp tests — they
test pthreads4w itself. The benchmark tests in particular exceed the 5-second
`--timeout` limit. Testing pthreads4w is pthreads4w's own CI job, not ours.

**Fix (`.github/workflows/ccpp.yml`):** Add `--exclude-regex "^pthreads4w"`
to `ctest_flags`. This skips the entire external pthreads4w test suite while
leaving the 5-second timeout in place (all pupnp-owned tests finish well under
that).

## Checklist
- [x] Configure succeeds on Ubuntu, macOS, MSys (`Threads::Shared` fixed)
- [x] Configure succeeds on Windows MSVC (CmDaB pinned, pthreads4w found)
- [x] pthreads4w tests excluded from CI (`--exclude-regex "^pthreads4w"`)
- [x] `upnp_shared` builds cleanly
- [x] No change in behaviour for non-CI builds (`DOWNLOAD_AND_BUILD_DEPS=OFF`)