### PR TITLE
feat: add UPNP_ENABLE_DEBUG option and expose UPNP_HAVE_DEBUG in upnpconfig.h

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -51,7 +51,7 @@ env:
   ctest_flags: |-
     --test-dir build \
     --output-on-failure \
-    --timeout 5 \
+    --timeout 30 \
     --exclude-regex "^pthreads4w"
 
 jobs:

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -25,6 +25,7 @@ UPNP_deprecated_option (ssdp UPNP_ENABLE_SSDP "SSDP part" ON)
 UPNP_deprecated_option (unspecified_server UPNP_ENABLE_UNSPECIFIED_SERVER "unspecified SERVER header" OFF)
 UPNP_deprecated_option (webserver UPNP_ENABLE_WEBSERVER "integrated web server" ${UPNP_ENABLE_DEVICE_API})
 UPNP_deprecated_option (reuseaddr UPNP_MINISERVER_REUSEADDR "Bind the miniserver socket with SO_REUSEADDR to allow clean restarts" ON)
+option (UPNP_ENABLE_DEBUG "debug logging (UpnpInitLog/UpnpSetLogLevel/UpnpGetDebugFile)" OFF)
 option (UPNP_ENABLE_BACKTRACE "Print backtrace on first thread pool overflow" ON)
 
 if (UPNP_ENABLE_WEBSERVER AND NOT UPNP_ENABLE_DEVICE_API)
@@ -33,6 +34,7 @@ endif()
 
 set (IXML_HAVE_SCRIPTSUPPORT ${IXML_ENABLE_SCRIPT_SUPPORT}) #see ixml.h
 set (UPNP_HAVE_CLIENT ${UPNP_ENABLE_CLIENT_API}) #see upnpconfig.h
+set (UPNP_HAVE_DEBUG ${UPNP_ENABLE_DEBUG}) #see upnpconfig.h
 set (UPNP_HAVE_DEVICE ${UPNP_ENABLE_DEVICE_API}) #see upnpconfig.h
 set (UPNP_HAVE_GENA ${UPNP_ENABLE_GENA}) #see upnpconfig.h
 set (UPNP_HAVE_OPTSSDP ${UPNP_ENABLE_OPTIONAL_SSDP_HEADERS}) #see upnpconfig.h

--- a/upnp/inc/upnpconfig.h.cm
+++ b/upnp/inc/upnpconfig.h.cm
@@ -105,6 +105,10 @@
  *  (i.e. configure --enable-tools) : <upnp/upnptools.h> file is available */
 #cmakedefine UPNP_HAVE_TOOLS 1
 
+/** Defined to 1 if the library has been compiled with debug logging enabled
+ *  (i.e. configure --enable-debug or cmake -DUPNP_ENABLE_DEBUG=ON) */
+#cmakedefine UPNP_HAVE_DEBUG 1
+
 /** Defined to 1 if the library has been compiled with ipv6 support
  *  (i.e. configure --enable-ipv6) */
 #cmakedefine UPNP_ENABLE_IPV6 1


### PR DESCRIPTION
## Problem

The CMake build had no equivalent of autotools `--enable-debug`. As a result `UPNP_HAVE_DEBUG` was never defined in CMake builds, so any downstream code (or tests) guarded by `#ifdef UPNP_HAVE_DEBUG` always saw the *debug-disabled* path — even in `CMAKE_BUILD_TYPE=Debug` configurations.

## Fix

* Add `UPNP_ENABLE_DEBUG` option to `cmake/options.cmake` (default `OFF`, matching the autotools default)
* Map it to `UPNP_HAVE_DEBUG` following the same `UPNP_ENABLE_* → UPNP_HAVE_*` convention used by all other options
* Expose `UPNP_HAVE_DEBUG` in the installed `upnpconfig.h` via a `#cmakedefine` entry
* Raise `ctest --timeout` from 5 s to 30 s — pthreads4w benchmarks are already excluded by `--exclude-regex "^pthreads4w"`, so the aggressive 5 s limit is no longer needed; 5 s proved too tight for Windows Debug CI runners under load (even empty gtests timed out)

After this change:

| Build system | Debug logging ON | `UPNP_HAVE_DEBUG` |
|---|---|---|
| autotools `--enable-debug` | yes | `1` |
| autotools (default) | no | undefined |
| cmake `-DUPNP_ENABLE_DEBUG=ON` | yes | `1` |
| cmake (default) | no | `/* #undef UPNP_HAVE_DEBUG */` |

## Checklist
- [x] `cmake -DUPNP_ENABLE_DEBUG=ON` → `#define UPNP_HAVE_DEBUG 1` in generated `upnpconfig.h`
- [x] `cmake -DUPNP_ENABLE_DEBUG=OFF` → `/* #undef UPNP_HAVE_DEBUG */`
- [x] All 60 tests pass locally
- [x] CI green