### PR TITLE
docs: document Upnp_FunPtr Event const removal in 1.18 API changes

### DIFF
--- a/docs/api_changes/v1_10.md
+++ b/docs/api_changes/v1_10.md
@@ -71,3 +71,39 @@ upnp/inc/FileInfo.h | upnp/inc/UpnpFileInfo.h
 upnp/inc/StateVarComplete.h | upnp/inc/UpnpStateVarComplete.h
 upnp/inc/StateVarRequest.h | upnp/inc/UpnpStateVarRequest.h
 upnp/inc/SubscriptionRequest.h | upnp/inc/UpnpSubscriptionRequest.h
+
+## Version 1.18
+
+### `Upnp_FunPtr` callback: `Event` parameter is no longer `const`
+
+The `Event` parameter in the `Upnp_FunPtr` typedef has changed from
+`const void *` to `void *`:
+
+```c
+/* 1.14.x (and earlier) */
+typedef int (*Upnp_FunPtr)(Upnp_EventType EventType, const void *Event, void *Cookie);
+
+/* 1.18.x and later */
+typedef int (*Upnp_FunPtr)(Upnp_EventType EventType, void *Event, void *Cookie);
+```
+
+The `const` qualifier was accidentally introduced in 2010 when the typedef was
+moved from `upnp.h` to `Callback.h`. It was semantically incorrect: for
+`UPNP_CONTROL_ACTION_REQUEST` and `UPNP_CONTROL_GET_VAR_REQUEST`, the library
+passes the Event structure to the callback so that the application can write
+its response back into it — making it an in-out parameter, not a read-only one.
+
+**Migration:** remove `const` from the `Event` parameter in your callback
+implementations:
+
+```c
+/* before */
+int my_callback(Upnp_EventType event_type, const void *event, void *cookie)
+
+/* after */
+int my_callback(Upnp_EventType event_type, void *event, void *cookie)
+```
+
+See [issue #528][gh-issue528] for the full history.
+
+[gh-issue528]: https://github.com/pupnp/pupnp/issues/528


### PR DESCRIPTION
## Summary

- Adds a Version 1.18 section to `docs/api_changes/v1_10.md` documenting the intentional removal of `const` from the `Event` parameter in `Upnp_FunPtr`
- Explains the rationale: `const` was accidentally introduced in 2010; the parameter is in-out for device-side action callbacks
- Provides a migration snippet for downstream maintainers

Closes #528