### PR TITLE
fix: change IN6_IS_ADDR_GLOBAL macro to accept all 2000::/3 addresses

### DIFF
--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -93,7 +93,7 @@
 #ifndef IN6_IS_ADDR_GLOBAL
 	#define IN6_IS_ADDR_GLOBAL(a) \
 		((((__const uint32_t *)(a))[0] & \
-			 htonl((uint32_t)0x70000000)) == \
+			 htonl((uint32_t)0xe0000000)) == \
 			htonl((uint32_t)0x20000000))
 #endif /* IS ADDR GLOBAL */
 


### PR DESCRIPTION
The Global Unicast addresses assigned by IANA should be allocated in 2000::/3 address space according to the RFC 3513, i.e. three most significant bits of address should be 001.

Current implementation checks for three less significant bits in most significant nibble. This effectively marks a000::/4 addresses as GUA addresses, while excludes 3000::/4 from GUA diapason.

Issue was introduced in the c86d963abe6a40499461946a38dfaf6958961e9f commit.

Fix uses correct bitmask for GUA address comparison.