### PR TITLE
OSS-Fuzz: Add new fuzzer targets HTTP request and response parsing

### DIFF
--- a/fuzzer/CMakeLists.txt
+++ b/fuzzer/CMakeLists.txt
@@ -2,18 +2,23 @@ cmake_minimum_required(VERSION 3.11)
 
 project(fuzzer LANGUAGES C)
 add_executable(FuzzIxml FuzzIxml.c)
+add_executable(FuzzHttp FuzzHttp.c)
 
 if(NOT DEFINED LOCAL_RUN)
 	message("LOCAL_RUN is not defined")
 
 	# GitHub Actions needs this like that
 	target_link_libraries(FuzzIxml ixml_static ${LIB_FUZZING_ENGINE})
+	target_include_directories(FuzzHttp PRIVATE ${CMAKE_SOURCE_DIR}/upnp/src/threadutil)
+	target_link_libraries(FuzzHttp upnp_static ${LIB_FUZZING_ENGINE})
 else()
 	message("LOCAL_RUN is ${LOCAL_RUN}")
 
 	set(MY_CUSTOM_PATH ..)
 	find_library(LIB_IXML ixml REQUIRED NO_DEFAULT_PATH PATHS ${MY_CUSTOM_PATH}/ixml/.libs)
+	find_library(LIB_UPNP upnp REQUIRED NO_DEFAULT_PATH PATHS ${MY_CUSTOM_PATH}/upnp/.libs)
 	set(LIB_UPNP_INCLUDE ${MY_CUSTOM_PATH}/upnp/inc)
+	set(LIB_UPNP_SRC_INCLUDE ${MY_CUSTOM_PATH}/upnp/src/inc)
 	set(LIB_IXML_INCLUDE ${MY_CUSTOM_PATH}/ixml/inc)
 
 	target_include_directories(FuzzIxml PUBLIC
@@ -21,4 +26,11 @@ else()
 		${LIB_IXML_INCLUDE})
 	target_link_libraries(FuzzIxml PRIVATE
 		${LIB_IXML} ${LIB_FUZZING_ENGINE})
+
+	target_include_directories(FuzzHttp PUBLIC
+		${LIB_UPNP_INCLUDE}
+		${LIB_UPNP_SRC_INCLUDE}
+		${LIB_IXML_INCLUDE})
+	target_link_libraries(FuzzHttp PRIVATE
+		${LIB_UPNP} ${LIB_IXML} ${LIB_FUZZING_ENGINE})
 endif()

--- a/fuzzer/FuzzHttp.c
+++ b/fuzzer/FuzzHttp.c
@@ -1,0 +1,29 @@
+#include "httpparser.h"
+#include <stddef.h>
+#include <stdint.h>
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{
+	http_parser_t parser;
+	int as_response;
+
+	if (Size < 1) {
+		return 0;
+	}
+
+	/* One leading byte selects request vs response parsing. */
+	as_response = Data[0] & 1;
+	Data += 1;
+	Size -= 1;
+
+	if (as_response) {
+		parser_response_init(&parser, HTTPMETHOD_GET);
+	} else {
+		parser_request_init(&parser);
+	}
+
+	parser_append(&parser, (const char *)Data, Size);
+
+	httpmsg_destroy(&parser.msg);
+	return 0;
+}


### PR DESCRIPTION
This PR creates a new OSS-Fuzz fuzzer targets HTTP request and response parsing, together with the build fix in OSS-Fuzz (https://github.com/google/oss-fuzz/pull/15779) to enable the new fuzzer.