### PR TITLE
fix: normalize remaining emitted header names to canonical casing

### DIFF
--- a/upnp/src/gena/gena_device.c
+++ b/upnp/src/gena/gena_device.c
@@ -449,8 +449,8 @@ static char *AllocGenaHeaders(
 	const DOMString propertySet)
 {
 	static const char *HEADER_LINE_1 =
-		"CONTENT-TYPE: text/xml; charset=\"utf-8\"\r\n";
-	static const char *HEADER_LINE_2A = "CONTENT-LENGTH: ";
+		"Content-Type: text/xml; charset=\"utf-8\"\r\n";
+	static const char *HEADER_LINE_2A = "Content-Length: ";
 	static const char *HEADER_LINE_2B = "\r\n";
 	static const char *HEADER_LINE_3 = "NT: upnp:event\r\n";
 	static const char *HEADER_LINE_4 = "NTS: upnp:propchange\r\n";

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -903,7 +903,7 @@ int http_Download(const char *url_str,
 		HTTPMETHOD_GET,
 		url.pathquery.buff,
 		url.pathquery.size,
-		"HOST: ",
+		"Host: ",
 		hoststr,
 		hostlen);
 	if (ret_code != 0) {
@@ -1069,7 +1069,7 @@ int MakeGenericMessage(http_method_t method,
 				1,
 				"s"
 				"bcDCU",
-				"HOST: ",
+				"Host: ",
 				hoststr,
 				hostlen);
 		}
@@ -2004,7 +2004,7 @@ int http_MakeMessage(membuffer *buf,
 				    method,
 				    url.pathquery.buff,
 				    url.pathquery.size,
-				    "HOST: ",
+				    "Host: ",
 				    url.hostport.text.buff,
 				    url.hostport.text.size) != 0)
 				goto error_handler;
@@ -2127,7 +2127,7 @@ int MakeGetMessageEx(const char *url_str,
 			HTTPMETHOD_GET,
 			url->pathquery.buff,
 			url->pathquery.size,
-			"HOST: ",
+			"Host: ",
 			hoststr,
 			hostlen,
 			pRangeSpecifier);

--- a/upnp/src/genlib/net/http/webserver.c
+++ b/upnp/src/genlib/net/http/webserver.c
@@ -913,7 +913,7 @@ static int CreateHTTPRangeResponseHeader(
 	RangeInput = strdup(ByteRangeSpecifier);
 	if (!RangeInput)
 		return HTTP_INTERNAL_SERVER_ERROR;
-	/* CONTENT-RANGE: bytes 222-3333/4000  HTTP_PARTIAL_CONTENT */
+	/* Content-Range: bytes 222-3333/4000  HTTP_PARTIAL_CONTENT */
 	if (StrStr(RangeInput, "bytes") == NULL ||
 		(Ptr = StrStr(RangeInput, "=")) == NULL) {
 		free(RangeInput);

--- a/upnp/src/inc/httpreadwrite.h
+++ b/upnp/src/inc/httpreadwrite.h
@@ -511,10 +511,10 @@ Format types:
 	'B':	arg = int status_code		-- appends content-length,
 content-type and HTML body for given code. 'b':	arg1 = const char *buf; arg2 =
 size_t buf_length memory ptr
-	'C':	(no args)			-- appends a HTTP CONNECTION:
+	'C':	(no args)			-- appends a HTTP Connection:
 close header depending on major, minor version. 'c':	(no args)
 -- appends CRLF "\r\n"
-	'D':	(no args)			-- appends HTTP DATE: header
+	'D':	(no args)			-- appends HTTP Date: header
 	'd':	arg = int number		-- appends decimal number
 	'G':	arg = range information		-- add range header
 	'h':	arg = off_t number		-- appends off_t number
@@ -522,17 +522,17 @@ close header depending on major, minor version. 'c':	(no args)
 	'L':	arg = language information	-- add Content-Language header
 if Accept-Language header is not empty and if WEB_SERVER_CONTENT_LANGUAGE is not
 empty 'N':	arg1 = off_t content_length	-- content-length header 'q':
-arg1 = http_method_t		-- request start line and HOST header arg2 =
+arg1 = http_method_t		-- request start line and Host header arg2 =
 (uri_type *) 'Q':	arg1 = http_method_t;		-- start line of request
 		arg2 = char* url;
 		arg3 = size_t url_length
 	'R':	arg = int status_code		-- adds a response start line
-	'S':	(no args)			-- appends HTTP SERVER: header
+	'S':	(no args)			-- appends HTTP Server: header
 	's':	arg = const char *		-- C_string
 	'T':	arg = char * content_type;	-- format e.g: "text/html";
 content-type header
 	't':	arg = time_t * gmt_time		-- appends time in RFC 1123 fmt
-	'U':	(no args)			-- appends HTTP USER-AGENT:
+	'U':	(no args)			-- appends HTTP User-Agent:
 header
 	'X':	arg = const char *		-- useragent; "redsonic" HTTP
 X-User-Agent: useragent \endverbatim

--- a/upnp/src/soap/soap_ctrlpt.c
+++ b/upnp/src/soap/soap_ctrlpt.c
@@ -276,7 +276,7 @@ static UPNP_INLINE int add_man_header(
 	/* change POST to M-POST */
 	if (membuffer_insert(headers, "M-", 2, 0) != 0)
 		return UPNP_E_OUTOF_MEMORY;
-	soap_action_hdr = strstr(headers->buf, "SOAPACTION:");
+	soap_action_hdr = strstr(headers->buf, "SOAPAction:");
 	/* can't fail */
 	assert(soap_action_hdr != NULL);
 	/* insert MAN header */
@@ -604,7 +604,7 @@ int SoapSendAction(char *action_url,
 		    &url,
 		    content_length,
 		    ContentTypeHeader,
-		    "SOAPACTION: \"",
+		    "SOAPAction: \"",
 		    service_type,
 		    "#",
 		    name.buf,
@@ -793,7 +793,7 @@ int SoapSendActionEx(char *action_url,
 		    &url,
 		    content_length,
 		    ContentTypeHeader,
-		    "SOAPACTION: \"",
+		    "SOAPAction: \"",
 		    service_type,
 		    "#",
 		    name.buf,
@@ -919,12 +919,12 @@ int SoapGetServiceVarStatus(char *action_url, char *var_name, char **var_value)
 		    SOAPMETHOD_POST,
 		    path.buf,
 		    path.length,
-		    "HOST: ",
+		    "Host: ",
 		    host.buf,
 		    host.length,
 		    content_length,
 		    ContentTypeHeader,
-		    "SOAPACTION: "
+		    "SOAPAction: "
 		    "\"urn:schemas-upnp-org:control-1-0#QueryStateVariable\"",
 		    xml_start,
 		    var_name,


### PR DESCRIPTION
## Summary

Normalizes the remaining HTTP header names that the library **emits** in
ALL-CAPS to their canonical casing. This is a follow-up to #347
(commit `4e2c2b7e`), which normalized *response* header names; this PR
covers the **request** and **GENA eventing** paths that #347 didn't touch.

Header names are case-insensitive on the wire, so this is spec-compliant
either way — but some naive peers perform **case-sensitive** string
matching, and the canonical spelling is the interoperable choice.

## Background

RFC 9110 §5.1 (and RFC 7230 §3.2) state that HTTP field names are
case-insensitive, so both `HOST:` and `Host:` are valid. In practice,
however, the near-universal convention is the canonical mixed-case
spelling, and lightweight/embedded HTTP parsers sometimes match field
names literally. #347 already moved the response path to title-case for
exactly this reason; this PR finishes the job for the headers pupnp sends
as a client / event source.

## What changed

Standard HTTP headers → title-case
SOAP header → SOAP-spec casing

## What was deliberately left UPPERCASE (and why)

The UPnP-specific headers are defined in **uppercase** by the UPnP Device
Architecture spec (§1 Discovery/SSDP, §4 Eventing/GENA), and naive UPnP
control points/devices match them case-sensitively against that spelling.
Changing them would risk breaking the exact class of peers this PR is
meant to help, so they are untouched:

- **SSDP** (`ssdp_device.c`, `ssdp_ctrlpt.c`): `HOST`, `NT`, `NTS`, `USN`,
  `ST`, `MX`, `MAN`, `EXT`, `OPT`, `LOCATION`, `CACHE-CONTROL` — these
  travel in HTTPU/HTTPMU datagrams, not HTTP-over-TCP.
- **GENA/SOAP protocol headers**: `NT`, `NTS`, `SID`, `SEQ`, `CALLBACK`,
  `TIMEOUT`, `MAN`, `EXT`.

`upnpapi.c` also keeps a comment reading `CONTENT-TYPE:` — it documents a
Linksys router's non-conforming output (the reason case-insensitive
*parsing* exists), not pupnp's own emission.

## Standards references

| Header | Reference |
|--------|-----------|
| Field names are case-insensitive | RFC 9110 §5.1; RFC 7230 §3.2 |
| `Host` | RFC 9110 §7.2; RFC 7230 §5.4 |
| `Content-Type` | RFC 9110 §8.3; RFC 7231 §3.1.1.5 |
| `Content-Length` | RFC 9110 §8.6; RFC 7230 §3.3.2 |
| `SOAPAction` | SOAP 1.1 (W3C Note, 8 May 2000) §6.1.1 |
| SSDP / GENA header names (left uppercase) | UPnP Device Architecture §1 (Discovery), §4 (Eventing) |