### PR TITLE
feat: allow Windows interface selection by adapter name (GUID)

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -171,6 +171,12 @@ jobs:
       matrix:
         sys: [ mingw64, mingw32, ucrt64, clang64 ]
         conf: [ Release, Debug ]
+        include:
+          # Exercise the opt-in UPNP_ADAPTER_UUID_NAME option on one
+          # representative toolchain/config combo.
+          - sys: mingw64
+            conf: Release
+            extra_cmake_flags: -DUPNP_ADAPTER_UUID_NAME=ON
     defaults:
       run:
         shell: msys2 {0}
@@ -209,6 +215,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.conf }} \
             -DIXML_ENABLE_TESTING_INTEGRATION=OFF \
             -DUPNP_ENABLE_TESTING_INTEGRATION=OFF \
+            ${{ matrix.extra_cmake_flags }} \
             -DCMAKE_INSTALL_PREFIX=${{ GITHUB.WORKSPACE }}/test-install
       - name: Build
         run: cmake --build build --config ${{ matrix.conf }}

--- a/cmake/autoconfig.h.in
+++ b/cmake/autoconfig.h.in
@@ -49,6 +49,10 @@
 /* see upnpconfig.h */
 #cmakedefine UPNP_MINISERVER_REUSEADDR 1
 
+/* On Windows, select the network interface by its adapter name (GUID) instead
+ * of the friendly name (see UpnpGetIfInfo in upnp/src/api/upnpapi.c). */
+#cmakedefine UPNP_ADAPTER_UUID_NAME 1
+
 /* Type for storing the length of struct sockaddr */
 #cmakedefine socklen_t 1
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -9,6 +9,7 @@ option (IXML_ENABLE_SCRIPT_SUPPORT "script support for IXML document tree, see i
 option (IXML_ENABLE_TESTING "enable tests for ixml" ${testing_default})
 option (IXML_ENABLE_TESTING_INTEGRATION "enable integrationtests for ixml" ${testing_default})
 
+option (UPNP_ADAPTER_UUID_NAME "on Windows, select the network interface by its adapter name (GUID) instead of the friendly name" OFF)
 option (UPNP_BUILD_SAMPLES "compilation of upnp/sample/ code" ON)
 option (UPNP_BUILD_SHARED "Build shared libraries" ON)
 option (UPNP_BUILD_STATIC "Build static libraries" ON)

--- a/upnp/inc/upnpconfig.h.cm
+++ b/upnp/inc/upnpconfig.h.cm
@@ -129,4 +129,9 @@
  * with SO_REUSEADDR (i.e. configure --enable_reuseaddr) */
 #cmakedefine UPNP_MINISERVER_REUSEADDR 1
 
+/** Defined to 1 if, on Windows, the library has been compiled to select the
+ *  network interface by its adapter name (GUID) instead of the friendly name
+ *  (i.e. cmake -DUPNP_ADAPTER_UUID_NAME=ON) */
+#cmakedefine UPNP_ADAPTER_UUID_NAME 1
+
 #endif /* UPNP_CONFIG_H */

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -3826,6 +3826,12 @@ int UpnpGetIfInfo(const char *IfName)
 		}
 		if (ifname_found == 0) {
 			/* We have found a valid interface name. Keep it. */
+	#ifdef UPNP_ADAPTER_UUID_NAME
+			strncpy(gIF_NAME,
+				adapts_item->AdapterName,
+				sizeof(gIF_NAME) - 1);
+			gIF_NAME[sizeof(gIF_NAME) - 1] = 0;
+	#else
 			/*
 			 * Partial fix for Windows: Friendly name is wchar
 			 * string, but currently gIF_NAME is char string. For
@@ -3840,9 +3846,18 @@ int UpnpGetIfInfo(const char *IfName)
 				adapts_item->FriendlyName,
 				sizeof(gIF_NAME));
 			free(s);
-
+	#endif
 			ifname_found = 1;
 		} else {
+	#ifdef UPNP_ADAPTER_UUID_NAME
+			if (strncmp(gIF_NAME,
+				    adapts_item->AdapterName,
+				    sizeof(gIF_NAME)) != 0) {
+				/* This is not the interface we're looking for.
+				 */
+				continue;
+			}
+	#else
 			/*
 			 * Partial fix for Windows: Friendly name is wchar
 			 * string, but currently gIF_NAME is char string. For
@@ -3866,6 +3881,7 @@ int UpnpGetIfInfo(const char *IfName)
 				 */
 				continue;
 			}
+	#endif
 		}
 		/* Loop thru this adapter's unicast IP addresses. */
 		uni_addr = adapts_item->FirstUnicastAddress;


### PR DESCRIPTION
## Summary

Adds an opt-in build option, `UPNP_ADAPTER_UUID_NAME` (default `OFF`), that
changes how `UpnpGetIfInfo()` identifies a network interface on Windows: by the
adapter's **AdapterName** (its GUID) instead of its **FriendlyName**.

## Motivation

On Windows, `UpnpGetIfInfo()` matches the requested interface against the
adapter's `FriendlyName` (e.g. "Ethernet", "Wi‑Fi", or a localized/renamed
label). Two problems follow from this:

1. **Lossy conversion.** `FriendlyName` is a wide-character (UTF‑16) string,
   but `gIF_NAME` is a narrow `char` buffer, so the code converts it with
   `wcstombs_s`. For adapters whose friendly name contains non-ASCII or
   localized characters, the conversion can be incomplete or fail, and the
   adapter then never matches — the interface effectively can't be selected.
   The existing code even documents this as a "partial fix … which will work
   with many (but not all) adapters."

2. **Unstable identifier.** Friendly names are user-editable and locale
   dependent. They can change when the user renames an adapter or switches the
   system language, which makes them a poor key for deterministic,
   reproducible interface selection.

`AdapterName`, by contrast, is a stable ASCII GUID string
(`{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}`) provided as `PCHAR`. It needs no
wide→narrow conversion, is unique, and does not change across renames or
locale changes. Applications that already obtain the adapter GUID from the
Windows networking APIs can then pass it straight to `UpnpGetIfInfo()` and get
deterministic selection.

## Behavior & compatibility

- Default is `OFF`; existing builds and the current FriendlyName behavior are
  completely unchanged.
- When enabled, callers pass the adapter GUID as the interface name.
- Affects Windows only; on other platforms the option has no effect.