### PR TITLE
fix: don't format an unset IPv4/IPv6 address in Windows UpnpGetIfInfo

### DIFF
--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -62,6 +62,31 @@ if (NOT WIN32 AND UPNP_BUILD_STATIC)
 	)
 endif()
 
+# regression test — Windows UpnpGetIfInfo() must not format an address
+# family that was not found on the interface (amule-org/amule#242, #301);
+# UpnpSetIfAddrStrings() is an internal symbol so only the static variant
+# is built.
+if (NOT WIN32 AND UPNP_BUILD_STATIC)
+	add_executable(test_upnpapi_setifaddrstrings-static
+		test_upnpapi_setifaddrstrings.cpp)
+	target_link_libraries(test_upnpapi_setifaddrstrings-static
+		PRIVATE upnp_static GTest::gtest)
+	target_include_directories(test_upnpapi_setifaddrstrings-static PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/../upnp/src/inc/
+		${CMAKE_CURRENT_SOURCE_DIR}/../upnp/src/threadutil/
+	)
+	if(HAVE_MACRO_PREFIX_MAP)
+		target_compile_options(test_upnpapi_setifaddrstrings-static
+			PRIVATE -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=
+		)
+	endif()
+	gtest_add_tests(
+		TARGET test_upnpapi_setifaddrstrings-static
+		TEST_PREFIX test-upnp-
+		TEST_SUFFIX -static
+	)
+endif()
+
 # regression test for issue #395 — sock_write must not pass MSG_DONTROUTE to
 # send() on TCP sockets; sock_write() is an internal symbol (hidden visibility
 # in the shared library) so only the static variant is built.

--- a/gtest/test_upnpapi_setifaddrstrings.cpp
+++ b/gtest/test_upnpapi_setifaddrstrings.cpp
@@ -1,0 +1,133 @@
+// regression: Windows UpnpGetIfInfo() must not format an address family
+// that was not found on the interface.
+//
+// Reported downstream in amule-org/amule#242 and amule-org/amule#301:
+// on Windows, disabling IPv6 on the network adapter made aMule's UPnP
+// port mapping fail completely, not just IPv6 discovery.
+//
+// Root cause: the _WIN32 branch of UpnpGetIfInfo() (upnp/src/api/upnpapi.c)
+// declared v6_addr uninitialized and called inet_ntop() into gIF_IPV6
+// unconditionally, even when no IPv6 address had been found for the
+// selected adapter. That formatted uninitialized stack bytes into a
+// syntactically valid but bogus address, which get_ssdp_sockets()
+// (upnp/src/ssdp/ssdp_server.c) then took as "IPv6 is available here" via
+// strlen(gIF_IPV6) > 0, tried and failed to join the SSDP multicast group,
+// and aborted SSDP setup for both IPv4 and IPv6 — killing discovery
+// entirely.
+//
+// Fix: UpnpSetIfAddrStrings() only formats an address family into its
+// output buffer when the caller reports that family as found.
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "upnpapi.h"
+}
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <netinet/in.h>
+
+TEST(UpnpSetIfAddrStringsTestSuite, v4_only_leaves_v6_buffer_untouched)
+{
+	struct in_addr v4_addr;
+	struct in_addr v4_netmask;
+	struct in6_addr v6_addr; // deliberately never populated
+	std::memset(&v4_addr, 0, sizeof(v4_addr));
+	std::memset(&v4_netmask, 0, sizeof(v4_netmask));
+	inet_pton(AF_INET, "192.168.1.42", &v4_addr);
+	inet_pton(AF_INET, "255.255.255.0", &v4_netmask);
+	// Poison v6_addr the way uninitialized stack memory would look,
+	// instead of leaving it zeroed like the rest of the test doubles.
+	std::memset(&v6_addr, 0xAA, sizeof(v6_addr));
+
+	char out_v4[INET_ADDRSTRLEN] = {0};
+	char out_v4_netmask[INET_ADDRSTRLEN] = {0};
+	char out_v6[INET6_ADDRSTRLEN] = "sentinel";
+
+	UpnpSetIfAddrStrings(1,
+		&v4_addr,
+		&v4_netmask,
+		out_v4,
+		sizeof(out_v4),
+		out_v4_netmask,
+		sizeof(out_v4_netmask),
+		0,
+		&v6_addr,
+		out_v6,
+		sizeof(out_v6));
+
+	EXPECT_STREQ(out_v4, "192.168.1.42");
+	EXPECT_STREQ(out_v4_netmask, "255.255.255.0");
+	EXPECT_STREQ(out_v6, "sentinel")
+		<< "v6 output buffer must be left untouched when no IPv6 "
+		   "address was found, not filled with a formatted garbage "
+		   "address";
+}
+
+TEST(UpnpSetIfAddrStringsTestSuite, v6_only_leaves_v4_buffers_untouched)
+{
+	struct in_addr v4_addr; // deliberately never populated
+	struct in_addr v4_netmask; // deliberately never populated
+	struct in6_addr v6_addr;
+	std::memset(&v4_addr, 0xAA, sizeof(v4_addr));
+	std::memset(&v4_netmask, 0xAA, sizeof(v4_netmask));
+	std::memset(&v6_addr, 0, sizeof(v6_addr));
+	inet_pton(AF_INET6, "fe80::1", &v6_addr);
+
+	char out_v4[INET_ADDRSTRLEN] = "sentinel";
+	char out_v4_netmask[INET_ADDRSTRLEN] = "sentinel";
+	char out_v6[INET6_ADDRSTRLEN] = {0};
+
+	UpnpSetIfAddrStrings(0,
+		&v4_addr,
+		&v4_netmask,
+		out_v4,
+		sizeof(out_v4),
+		out_v4_netmask,
+		sizeof(out_v4_netmask),
+		1,
+		&v6_addr,
+		out_v6,
+		sizeof(out_v6));
+
+	EXPECT_STREQ(out_v4, "sentinel");
+	EXPECT_STREQ(out_v4_netmask, "sentinel");
+	EXPECT_STREQ(out_v6, "fe80::1");
+}
+
+TEST(UpnpSetIfAddrStringsTestSuite, both_found_formats_both)
+{
+	struct in_addr v4_addr;
+	struct in_addr v4_netmask;
+	struct in6_addr v6_addr;
+	inet_pton(AF_INET, "10.0.0.5", &v4_addr);
+	inet_pton(AF_INET, "255.0.0.0", &v4_netmask);
+	inet_pton(AF_INET6, "fe80::5", &v6_addr);
+
+	char out_v4[INET_ADDRSTRLEN] = {0};
+	char out_v4_netmask[INET_ADDRSTRLEN] = {0};
+	char out_v6[INET6_ADDRSTRLEN] = {0};
+
+	UpnpSetIfAddrStrings(1,
+		&v4_addr,
+		&v4_netmask,
+		out_v4,
+		sizeof(out_v4),
+		out_v4_netmask,
+		sizeof(out_v4_netmask),
+		1,
+		&v6_addr,
+		out_v6,
+		sizeof(out_v6));
+
+	EXPECT_STREQ(out_v4, "10.0.0.5");
+	EXPECT_STREQ(out_v4_netmask, "255.0.0.0");
+	EXPECT_STREQ(out_v6, "fe80::5");
+}
+
+int main(int argc, char **argv)
+{
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -3720,6 +3720,35 @@ static unsigned UpnpComputeIpv6PrefixLength(struct sockaddr_in6 *Netmask)
 	return prefix_length;
 }
 
+/* Only format an address family that was actually found: formatting an
+ * unset v4/v6 storage would encode whatever bytes are in it (possibly
+ * uninitialized) into a syntactically valid but bogus address string,
+ * which downstream code (SSDP, GENA, the miniserver) then treats as
+ * "this protocol is available on the interface". */
+void UpnpSetIfAddrStrings(int valid_v4_addr_found,
+	const struct in_addr *v4_addr,
+	const struct in_addr *v4_netmask,
+	char *out_v4,
+	size_t out_v4_len,
+	char *out_v4_netmask,
+	size_t out_v4_netmask_len,
+	int valid_v6_addr_found,
+	const struct in6_addr *v6_addr,
+	char *out_v6,
+	size_t out_v6_len)
+{
+	if (valid_v4_addr_found) {
+		inet_ntop(AF_INET, v4_addr, out_v4, out_v4_len);
+		inet_ntop(AF_INET,
+			v4_netmask,
+			out_v4_netmask,
+			out_v4_netmask_len);
+	}
+	if (valid_v6_addr_found) {
+		inet_ntop(AF_INET6, v6_addr, out_v6, out_v6_len);
+	}
+}
+
 int UpnpGetIfInfo(const char *IfName)
 {
 #ifdef _WIN32
@@ -3732,12 +3761,20 @@ int UpnpGetIfInfo(const char *IfName)
 	SOCKADDR *ip_addr;
 	struct in_addr v4_addr;
 	struct in_addr v4_netmask;
-	struct in6_addr v6_addr;
+	struct in6_addr v6_addr = {0};
 	ULONG adapts_sz = 0;
 	ULONG mask = 0;
 	ULONG ret;
 	int ifname_found = 0;
 	int valid_addr_found = 0;
+	int valid_v4_addr_found = 0;
+	int valid_v6_addr_found = 0;
+
+	/* Clear stale IPv6 address from any previous initialization so that
+	 * a network change (or IPv6 being disabled on the interface) does
+	 * not leave gIF_IPV6 pointing at an address that is no longer valid
+	 * (issue #195). */
+	gIF_IPV6[0] = '\0';
 
 	/* Get Adapters addresses required size. */
 	ret = GetAdaptersAddresses(AF_UNSPEC,
@@ -3898,6 +3935,7 @@ int UpnpGetIfInfo(const char *IfName)
 					<< (32 - uni_addr->OnLinkPrefixLength));
 				memcpy(&v4_netmask, &mask, sizeof(v4_netmask));
 				valid_addr_found = 1;
+				valid_v4_addr_found = 1;
 				break;
 			case AF_INET6:
 				/* TODO: Retrieve IPv6 ULA or GUA address and
@@ -3913,6 +3951,7 @@ int UpnpGetIfInfo(const char *IfName)
 						sizeof(v6_addr));
 					/* TODO: Retrieve IPv6 LLA prefix */
 					valid_addr_found = 1;
+					valid_v6_addr_found = 1;
 				}
 				break;
 			default:
@@ -3944,12 +3983,17 @@ int UpnpGetIfInfo(const char *IfName)
 			"use.\n");
 		return UPNP_E_INVALID_INTERFACE;
 	}
-	inet_ntop(AF_INET, &v4_addr, gIF_IPV4, sizeof(gIF_IPV4));
-	inet_ntop(AF_INET,
+	UpnpSetIfAddrStrings(valid_v4_addr_found,
+		&v4_addr,
 		&v4_netmask,
+		gIF_IPV4,
+		sizeof(gIF_IPV4),
 		gIF_IPV4_NETMASK,
-		sizeof(gIF_IPV4_NETMASK));
-	inet_ntop(AF_INET6, &v6_addr, gIF_IPV6, sizeof(gIF_IPV6));
+		sizeof(gIF_IPV4_NETMASK),
+		valid_v6_addr_found,
+		&v6_addr,
+		gIF_IPV6,
+		sizeof(gIF_IPV6));
 #else
 	struct ifaddrs *ifap, *ifa;
 	struct in_addr v4_addr = {0};

--- a/upnp/src/inc/upnpapi.h
+++ b/upnp/src/inc/upnpapi.h
@@ -310,6 +310,23 @@ int UpnpGetIfInfo(
 	/*! [in] Interface name (can be NULL). */
 	const char *IfName);
 
+/*!
+ * \brief Format the discovered v4/v6 interface addresses into their
+ * output string buffers, but only for the address families that were
+ * actually found (valid_v4_addr_found / valid_v6_addr_found).
+ */
+void UpnpSetIfAddrStrings(int valid_v4_addr_found,
+	const struct in_addr *v4_addr,
+	const struct in_addr *v4_netmask,
+	char *out_v4,
+	size_t out_v4_len,
+	char *out_v4_netmask,
+	size_t out_v4_netmask_len,
+	int valid_v6_addr_found,
+	const struct in6_addr *v6_addr,
+	char *out_v6,
+	size_t out_v6_len);
+
 void UpnpThreadDistribution(struct UpnpNonblockParam *Param);
 
 /*!


### PR DESCRIPTION
## Summary

On Windows, `UpnpGetIfInfo()` called `inet_ntop()` on `v4_addr`/`v6_addr` unconditionally, even when `GetAdaptersAddresses` had not found that address family on the selected adapter. That encoded whatever bytes were in the (possibly uninitialized) local storage into `gIF_IPV4`/`gIF_IPV6` as a syntactically valid but bogus address.

When IPv6 is disabled on the adapter, the resulting non-empty but bogus `gIF_IPV6` makes `get_ssdp_sockets()` believe IPv6 is available and try to join the SSDP multicast group on it, which fails and — unlike the miniserver TCP socket path, which already falls back to IPv4-only — aborts SSDP setup for **both** IPv4 and IPv6, breaking UPnP discovery entirely.

Reported downstream in amule-org/amule#242 and amule-org/amule#301, where disabling IPv6 on the Windows network adapter made aMule's UPnP port mapping fail completely.

- Track `valid_v4_addr_found`/`valid_v6_addr_found` independently, as the POSIX/BSD branch of this same function already does.
- Only format an address family into its output buffer when it was actually found, via a new platform-independent helper, `UpnpSetIfAddrStrings()`.
- Clear stale `gIF_IPV6` before each scan, mirroring the existing issue #195 fix for the POSIX branch, so a re-init after IPv6 is disabled doesn't leave a stale address behind either.

## Test plan

- [x] Added `gtest/test_upnpapi_setifaddrstrings.cpp`, exercising `UpnpSetIfAddrStrings()` directly (v4-only, v6-only, both-found cases). It's platform-independent (no `GetAdaptersAddresses`/`getifaddrs` dependency), so it runs on Linux CI via the existing static-lib/internal-symbol pattern (`gtest/CMakeLists.txt`, alongside `test_miniserver`/`test_gena`/`test_sock`/`test_httpreadwrite`).
- [x] Confirmed the test reproduces the bug: temporarily restored the original unconditional `inet_ntop()` calls and observed the v4-only/v6-only cases fail with a garbage-formatted address (e.g. `aaaa:aaaa:aaaa:...`), then restored the fix and confirmed they pass.
- [x] Full local `ctest` run: 83/83 passing, including the existing `Issue195`/`Issue247`/`Issue598` regression tests that also touch `UpnpGetIfInfo`/`gIF_IPV6`, confirming the POSIX/BSD branch is untouched.
- [ ] Windows CI (`windows-msvc`, `windows-msys2`) — this PR's code path only compiles under `_WIN32`, so those jobs are the only place the real `GetAdaptersAddresses` integration can be exercised; watching them on this PR.