### PR TITLE
fix: avoid unlocking GlobalHndRWLock without holding it in UpnpSetContentLength

### DIFF
--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -4797,32 +4797,31 @@ int UpnpVirtualDir_set_CloseCallback(VDCallback_Close callback)
 
 int UpnpSetContentLength(UpnpClient_Handle Hnd, size_t contentLength)
 {
-	int errCode = UPNP_E_SUCCESS;
 	struct Handle_Info *HInfo = NULL;
+	int errCode = UPNP_E_SUCCESS;
 
-	do {
-		if (UpnpSdkInit != 1) {
-			errCode = UPNP_E_FINISH;
-			break;
-		}
+	if (UpnpSdkInit != 1) {
+		return UPNP_E_FINISH;
+	}
 
-		HandleLock(__FILE__, __LINE__);
+	HandleLock(__FILE__, __LINE__);
 
-		switch (GetHandleInfo(Hnd, &HInfo)) {
-		case HND_DEVICE:
-			break;
-		default:
-			HandleUnlock(__FILE__, __LINE__);
-			return UPNP_E_INVALID_HANDLE;
-		}
-		if (contentLength > MAX_SOAP_CONTENT_LENGTH) {
-			errCode = UPNP_E_OUTOF_BOUNDS;
-			break;
-		}
-		g_maxContentLength = contentLength;
-	} while (0);
+	switch (GetHandleInfo(Hnd, &HInfo)) {
+	case HND_DEVICE:
+		break;
+	default:
+		errCode = UPNP_E_INVALID_HANDLE;
+		goto exit;
+	}
+	if (contentLength > MAX_SOAP_CONTENT_LENGTH) {
+		errCode = UPNP_E_OUTOF_BOUNDS;
+		goto exit;
+	}
+	g_maxContentLength = contentLength;
 
+exit:
 	HandleUnlock(__FILE__, __LINE__);
+
 	return errCode;
 }
 


### PR DESCRIPTION
## Summary
- `UpnpSetContentLength()` used a `do{}while(0)` + `break` idiom where the `UpnpSdkInit != 1` early-exit skipped `HandleLock()` but still fell through to the function's unconditional `HandleUnlock()`, unlocking `GlobalHndRWLock` without ever holding it.
- This is undefined behavior on the underlying `pthread_rwlock_t`, and is particularly unsafe here since `GlobalHndRWLock` is initialized/destroyed around the `UpnpSdkInit` flag itself (calls made before init or after `UpnpFinish()` could touch an uninitialized or already-destroyed lock).
- Replaced the idiom with direct `return`s before the lock is taken, and `goto exit` (reached only after `HandleLock()`) for the post-lock exit paths, so `HandleUnlock()` is only ever called when the lock is actually held.

## Test plan
- [x] `cmake -S . -B build -DUPNP_ENABLE_IPV6=ON -DUPNP_MINISERVER_REUSEADDR=ON && cmake --build build --target upnp_shared upnp_static` — builds clean, no warnings on `upnpapi.c`
- [ ] CI