### PR TITLE
docs: add 22.0.3 to README release list

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The Portable SDK for UPnP&trade; Devices is distributed under the BSD (Berkeley 
 
 | Release Number | Date       | History                                  |
 | -------------- | ---------- | ---------------------------------------- |
+| 22.0.3         | 2026-07-14 | [Portable UPnP SDK][Portable UPnP SDK]   |
 | 2.0.2          | 2026-06-17 | [Portable UPnP SDK][Portable UPnP SDK]   |
 | 2.0.1          | 2026-06-17 | [Portable UPnP SDK][Portable UPnP SDK]   |
 | 2.0.0          | 2026-06-16 | [Portable UPnP SDK][Portable UPnP SDK]   |


### PR DESCRIPTION
## Summary
- Adds the `22.0.3` row to `README.md`'s release history table, released 2026-07-14 (draft release: https://github.com/pupnp/pupnp/releases/tag/release-22.0.3).

Last remaining step of the `release-22.0.3` release checklist.