### PR TITLE
docs: update security policy for current version and process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,8 @@ Versions currently being supported with security updates:
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 1.18.x   | :white_check_mark: |
-| 1.14.x   | :x:                |
-| < 1.14.x | :x:                |
+| 22.0.x   | :white_check_mark: |
+| < 22.0.x | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -30,3 +29,12 @@ This is an open source free project and as such we have our limitations.
 
 Nonetheless, we will try to provide a fix for the problem as soon as possible
 and request that you do not disclose the issue publicly until we have released a patch.
+
+If you would like to contribute the fix yourself, we do not accept public pull
+requests for an unpatched vulnerability, since that would expose the issue
+before a fix is available to users. Instead, we can set up a temporary private
+fork attached to the advisory so you can collaborate with us and submit your
+patch there directly.
+
+Once a fix is released, we publish the advisory and request a CVE ID through
+GitHub.


### PR DESCRIPTION
## Summary
- Supported-versions table was still listing 1.18.x/1.14.x; updated to reflect current 22.0.x release line
- Documented the temporary-private-fork option for reporters who want to submit their own patch (used on GHSA-279g-pwr2-f8r2 and GHSA-hg5x-73vf-vfm2)
- Documented that a CVE is requested at publish time