### PR TITLE
fix: OmniOS link failure + branch-status table fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 | branch         | status                                                                                              |
 | -------------- | --------------------------------------------------------------------------------------------------- |
-| main  (2.0.x)  | ![main](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=main)            |
+| main  (22.0.x) | ![main](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=main)            |
+| branch-2.0.x   | ![2.0.x](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=branch-2.0.x)   |
 | branch-1.18.x  | ![1.18.x](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=branch-1.18.x) |
 | branch-1.14.x  | ![1.14.x](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=branch-1.14.x) |
 | branch-1.12.x  | ![1.12.x](https://github.com/pupnp/pupnp/actions/workflows/ccpp.yml/badge.svg?branch=branch-1.12.x) |

--- a/upnp/test/CMakeLists.txt
+++ b/upnp/test/CMakeLists.txt
@@ -271,13 +271,6 @@ UPNP_Add_Unit_Test(test-upnp-gh-153 poc_gh_153.c)
 # Uses the same web_server_ut_* hooks and requires Threads::Threads because
 # the test spawns a background thread with pthread_create.
 UPNP_Add_Unit_Test(test-upnp-gh-325 poc_gh_325.c)
-
-# GHSA-279g-pwr2-f8r2: embedded NUL byte (%00) in a request path is decoded
-# to a literal NUL by remove_escaped_chars(), but downstream alias/routing
-# checks in webserver.c use NUL-terminated string functions, so bytes after
-# the NUL are silently dropped and the request wrongly matches a shorter
-# registered alias.  Uses the same web_server_ut_set_alias hook.
-UPNP_Add_Unit_Test(test-upnp-ghsa-f8r2 poc_ghsa_f8r2_nullbyte.c)
 if(UPNP_BUILD_SHARED)
 	target_link_libraries(test-upnp-gh-325 PRIVATE
 		Threads::Threads
@@ -288,6 +281,25 @@ endif()
 if(UPNP_BUILD_STATIC)
 	target_link_libraries(test-upnp-gh-325-static PRIVATE
 		Threads::Threads
+		$<$<BOOL:${SOCKET_LIBRARY}>:${SOCKET_LIBRARY}>
+		$<$<BOOL:${NSL_LIBRARY}>:${NSL_LIBRARY}>
+	)
+endif()
+
+# GHSA-279g-pwr2-f8r2: embedded NUL byte (%00) in a request path is decoded
+# to a literal NUL by remove_escaped_chars(), but downstream alias/routing
+# checks in webserver.c use NUL-terminated string functions, so bytes after
+# the NUL are silently dropped and the request wrongly matches a shorter
+# registered alias.  Uses the same web_server_ut_set_alias hook.
+UPNP_Add_Unit_Test(test-upnp-ghsa-f8r2 poc_ghsa_f8r2_nullbyte.c)
+if(UPNP_BUILD_SHARED)
+	target_link_libraries(test-upnp-ghsa-f8r2 PRIVATE
+		$<$<BOOL:${SOCKET_LIBRARY}>:${SOCKET_LIBRARY}>
+		$<$<BOOL:${NSL_LIBRARY}>:${NSL_LIBRARY}>
+	)
+endif()
+if(UPNP_BUILD_STATIC)
+	target_link_libraries(test-upnp-ghsa-f8r2-static PRIVATE
 		$<$<BOOL:${SOCKET_LIBRARY}>:${SOCKET_LIBRARY}>
 		$<$<BOOL:${NSL_LIBRARY}>:${NSL_LIBRARY}>
 	)


### PR DESCRIPTION
## Summary
- `test-upnp-ghsa-f8r2` (GHSA-279g regression test) was breaking OmniOS CI: it calls `socket()`/`connect()`/`send()`/`recv()` directly, same as `test-upnp-gh-325`, but was registered without the `SOCKET_LIBRARY`/`NSL_LIBRARY` linkage those symbols need outside glibc. Also fixes a stray placement bug where its registration had landed between `gh-325`'s registration and `gh-325`'s own linking block.
- README branch-status table: `main (2.0.x)` label was stale (version scheme moved to `22.0.x`), and `branch-2.0.x` was missing entirely — 2.0.x was a real released line with no maintenance branch, unlike every other row. Created `branch-2.0.x` pointing at `release-2.0.2`, matching how `branch-1.18.x` etc. point at their last release.

## Test plan
- [x] Full local test suite (116 tests) passes with the CMakeLists.txt fix applied
- [ ] OmniOS CI job (`ccpp.yml`) passes on this branch