### PR TITLE
OSS-Fuzz: Add new fuzzer targets service table processing

### DIFF
--- a/fuzzer/CMakeLists.txt
+++ b/fuzzer/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.11)
 project(fuzzer LANGUAGES C)
 add_executable(FuzzIxml FuzzIxml.c)
 add_executable(FuzzHttp FuzzHttp.c)
+add_executable(FuzzServiceTable FuzzServiceTable.c)
 
 if(NOT DEFINED LOCAL_RUN)
 	message("LOCAL_RUN is not defined")
@@ -11,6 +12,8 @@ if(NOT DEFINED LOCAL_RUN)
 	target_link_libraries(FuzzIxml ixml_static ${LIB_FUZZING_ENGINE})
 	target_include_directories(FuzzHttp PRIVATE ${CMAKE_SOURCE_DIR}/upnp/src/threadutil)
 	target_link_libraries(FuzzHttp upnp_static ${LIB_FUZZING_ENGINE})
+	target_include_directories(FuzzServiceTable PRIVATE ${CMAKE_SOURCE_DIR}/upnp/src/threadutil)
+	target_link_libraries(FuzzServiceTable upnp_static ${LIB_FUZZING_ENGINE})
 else()
 	message("LOCAL_RUN is ${LOCAL_RUN}")
 
@@ -32,5 +35,12 @@ else()
 		${LIB_UPNP_SRC_INCLUDE}
 		${LIB_IXML_INCLUDE})
 	target_link_libraries(FuzzHttp PRIVATE
+		${LIB_UPNP} ${LIB_IXML} ${LIB_FUZZING_ENGINE})
+
+	target_include_directories(FuzzServiceTable PUBLIC
+		${LIB_UPNP_INCLUDE}
+		${LIB_UPNP_SRC_INCLUDE}
+		${LIB_IXML_INCLUDE})
+	target_link_libraries(FuzzServiceTable PRIVATE
 		${LIB_UPNP} ${LIB_IXML} ${LIB_FUZZING_ENGINE})
 endif()

--- a/fuzzer/FuzzServiceTable.c
+++ b/fuzzer/FuzzServiceTable.c
@@ -1,0 +1,39 @@
+#include "service_table.h"
+
+#include "ixml.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{
+	IXML_Document *doc = NULL;
+	service_table table;
+	char *xml;
+
+	if (Size < 1 || Size > 65536) {
+		return 0;
+	}
+
+	xml = malloc(Size + 1);
+	if (!xml) {
+		return 0;
+	}
+	memcpy(xml, Data, Size);
+	xml[Size] = '\0';
+
+	/* A control point parses the device description document fetched from a
+	 * device, then builds the service table from it. */
+	if (ixmlParseBufferEx(xml, &doc) == IXML_SUCCESS && doc) {
+		memset(&table, 0, sizeof(table));
+		getServiceTable((IXML_Node *)doc, &table, "http://127.0.0.1/");
+		freeServiceTable(&table);
+		ixmlDocument_free(doc);
+	}
+
+	free(xml);
+
+	return 0;
+}

--- a/fuzzer/FuzzServiceTable.c
+++ b/fuzzer/FuzzServiceTable.c
@@ -1,6 +1,8 @@
 #include "service_table.h"
 
-#include "ixml.h"
+/* "ixml.h" is not included here on purpose: service_table.h already includes
+ * it, together with the other headers this target needs (config.h, upnp.h,
+ * LinkedList.h). */
 
 #include <stddef.h>
 #include <stdint.h>
@@ -9,10 +11,24 @@
 
 extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
+/* service_table, getServiceTable() and freeServiceTable() are only declared
+ * when the device APIs and GENA are compiled in. Without this guard the
+ * target fails to build on a client-only configuration, for instance
+ * cmake -DFUZZER=ON -DUPNP_ENABLE_DEVICE_API=OFF. */
+#if defined(INCLUDE_DEVICE_APIS) && EXCLUDE_GENA == 0
 	IXML_Document *doc = NULL;
 	service_table table;
 	char *xml;
 
+	/* The upper bound is a harness-side safety net only. The input size is
+	 * meant to be driven by the runner, through libFuzzer's -max_len flag:
+	 * on the command line, as in
+	 *     ./FuzzServiceTable corpus/ -max_len=65536
+	 * or, under OSS-Fuzz, through a FuzzServiceTable.options file holding
+	 *     [libfuzzer]
+	 *     max_len = 65536
+	 * Neither is set today, so libFuzzer's own default of 4096 bytes
+	 * applies and the test below never actually fires. */
 	if (Size < 1 || Size > 65536) {
 		return 0;
 	}
@@ -34,6 +50,10 @@ extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 	}
 
 	free(xml);
+#else
+	(void)Data;
+	(void)Size;
+#endif
 
 	return 0;
 }

--- a/upnp/test/poc_ghsa_f8r2_nullbyte.c
+++ b/upnp/test/poc_ghsa_f8r2_nullbyte.c
@@ -46,8 +46,8 @@ extern int web_server_ut_set_alias(
 /* The miniserver rejects requests whose Host header isn't a numeric
  * ip:port (DNS-rebinding protection), so the Host header below must
  * match the server's own address. */
-static int get_status_code(const char *ip, unsigned short port,
-	const char *path)
+static int get_status_code(
+	const char *ip, unsigned short port, const char *path)
 {
 	int sock;
 	struct sockaddr_in addr;
@@ -82,8 +82,7 @@ static int get_status_code(const char *ip, unsigned short port,
 	send(sock, req, strlen(req), MSG_NOSIGNAL);
 
 	while (total < sizeof buf - 1 &&
-		(n = recv(sock, buf + total, sizeof buf - 1 - total, 0)) >
-			0) {
+		(n = recv(sock, buf + total, sizeof buf - 1 - total, 0)) > 0) {
 		total += (size_t)n;
 	}
 	buf[total] = '\0';


### PR DESCRIPTION
This PR creates a new OSS-Fuzz fuzzer targets service table processing, together with the build fix in OSS-Fuzz (https://github.com/google/oss-fuzz/pull/16102) to enable the new fuzzer.