### PR TITLE
ci: fix CIFuzz trigger and make it manual

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,14 +1,16 @@
 name: CIFuzz
 
 on:
+  # CIFuzz builds every target and then fuzzes for 5 minutes, so it is too
+  # expensive to run on every pull request. Run it on demand, and
+  # automatically only when the fuzzing harnesses themselves change.
+  workflow_dispatch:
   pull_request:
     branches:
+      - "**"
       - "!no_ci-*"
     paths:
-      - "**.c"
-      - "**.cpp"
-      - "**.h"
-      - "**.hpp"
+      - "fuzzer/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
CIFuzz has not run since 1bf05391 (7 Feb 2026). The last run on record is 21788358878, from that same day.

The cause is the branch filter added in that commit:

```yaml
on:
  pull_request:
    branches:
      - "!no_ci-*"
```

A `branches` list made only of negative patterns matches nothing, so the `pull_request` event never fires. `ccpp.yml` and `clang-format.yml` were changed in the same commit but kept a positive `"**"` entry ahead of the exclusion, which is why only CIFuzz broke.

This restores the positive pattern. Since a full fuzzer build plus five minutes of fuzzing is too expensive to run on every pull request, it also adds `workflow_dispatch` for on-demand runs and narrows the automatic ones to changes under `fuzzer/`, which is where a fuzzing regression would actually come from.

Note that for `pull_request`, `branches` filters the base branch, not the head, so the `!no_ci-*` entry never had the intended effect in any of the three workflows. Skipping by head-branch name would need a job-level `if: ${{ !startsWith(github.head_ref, 'no_ci-') }}`. Kept here for consistency; changing it is a separate matter.

This PR touches only `.github/workflows/cifuzz.yml`, which the new paths filter excludes, so CIFuzz will not run on this PR. Verification is a manual dispatch from the Actions tab after merge.